### PR TITLE
Bugfix/valid until includes date

### DIFF
--- a/Sources/CovidCertificateSDK/Date.swift
+++ b/Sources/CovidCertificateSDK/Date.swift
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Foundation
+
+extension Date {
+    static func fromISO8601(_ dateString:String) -> Date? {
+        // `ISO8601DateFormatter` does not support fractional zeros if not
+        // configured (`.withFractionalSeconds`) and if configured, does not
+        // parse dates without fractional seconds.
+
+        let formatter = ISO8601DateFormatter()
+
+        // Try to parse without fractional seconds
+        if let d = formatter.date(from: dateString) {
+            return d
+        }
+
+        // Retry with fraction
+        formatter.formatOptions = [.withFractionalSeconds]
+        if let d = formatter.date(from: dateString) {
+            return d
+        }
+
+        return nil
+    }
+}

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesVerifier.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesVerifier.swift
@@ -14,6 +14,9 @@ import Foundation
 let PCR_TEST_VALIDITY_IN_HOURS = 72
 let RAT_TEST_VALIDITY_IN_HOURS = 24
 let SINGLE_VACCINE_VALIDITY_OFFSET_IN_DAYS = 15
+// indicated valid until date is always included
+let MAXIMUM_VALIDITY_IN_DAYS = 179
+let INFECTION_VALIDITY_OFFSET_IN_DAYS = 10
 let DATE_FORMAT = "yyyy-MM-dd"
 
 public enum NationalRulesError: Error, Equatable {

--- a/Sources/CovidCertificateSDK/ehn/EuHealthCert.swift
+++ b/Sources/CovidCertificateSDK/ehn/EuHealthCert.swift
@@ -189,12 +189,12 @@ public struct Test: Codable {
     }
 
     public var validFromDate: Date? {
-        return ISO8601DateFormatter().date(from: timestampSample)
+        return Date.fromISO8601(timestampSample)
     }
 
     public var resultDate: Date? {
         if let res = timestampResult {
-            return ISO8601DateFormatter().date(from: res)
+            return Date.fromISO8601(res)
         }
 
         return nil

--- a/Sources/CovidCertificateSDK/ehn/EuHealthCert.swift
+++ b/Sources/CovidCertificateSDK/ehn/EuHealthCert.swift
@@ -142,7 +142,7 @@ public struct Vaccination: Codable {
     /// Vaccines are valid for 180 days
     public var validUntilDate: Date? {
         guard let dateOfVaccination = self.dateOfVaccination,
-              let date = Calendar.current.date(byAdding: DateComponents(day: 180), to: dateOfVaccination) else {
+              let date = Calendar.current.date(byAdding: DateComponents(day: MAXIMUM_VALIDITY_IN_DAYS), to: dateOfVaccination) else {
             return nil
         }
         return date
@@ -283,7 +283,7 @@ public struct PastInfection: Codable {
 
     public var validFromDate: Date? {
         guard let firstPositiveTestResultDate = self.firstPositiveTestResultDate,
-              let date = Calendar.current.date(byAdding: DateComponents(day: 10), to: firstPositiveTestResultDate) else {
+              let date = Calendar.current.date(byAdding: DateComponents(day: INFECTION_VALIDITY_OFFSET_IN_DAYS), to: firstPositiveTestResultDate) else {
             return nil
         }
         return date
@@ -291,7 +291,7 @@ public struct PastInfection: Codable {
 
     public var validUntilDate: Date? {
         guard let firstPositiveTestResultDate = self.firstPositiveTestResultDate,
-              let date = Calendar.current.date(byAdding: DateComponents(day: 180), to: firstPositiveTestResultDate) else {
+              let date = Calendar.current.date(byAdding: DateComponents(day: MAXIMUM_VALIDITY_IN_DAYS), to: firstPositiveTestResultDate) else {
             return nil
         }
         return date

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -498,7 +498,7 @@ final class CovidCertificateSDKTests: XCTestCase {
     }
 
     func testCertificateIsValidFor180DaysAfterTestResult() {
-        // The certificate was issued 180 days ago, which means it is still valid today
+        // The certificate was issued 179 days ago, which means it is still valid today
         let hcert = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -179), tg: Disease.SarsCov2.rawValue)
         verifier.checkNationalRules(dgc: hcert) { result in
             switch result {
@@ -509,7 +509,7 @@ final class CovidCertificateSDKTests: XCTestCase {
                 XCTAssertTrue(false)
             }
         }
-        // the certificate should not be valid anymore, since it was issued yesterday 180 days ago (hence now it is 181 day ago)
+        // the certificate should not be valid anymore, since it was issued yesterday 179 days ago (hence now it is 180 day ago)
         let hcert_invalid = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -180), tg: Disease.SarsCov2.rawValue)
         verifier.checkNationalRules(dgc: hcert_invalid) { result in
             switch result {

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -496,9 +496,55 @@ final class CovidCertificateSDKTests: XCTestCase {
             }
         }
     }
+    
+    func testSanityCheckForDateCalculations() {
+        var dateFormatter: DateFormatter {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = DATE_FORMAT
+            return dateFormatter
+        }
+      
+        let validTestResult = dateFormatter.date(from: "2021-05-08")!
+        let calculatedValidUntil = Calendar.current.date(byAdding: DateComponents(day: 179), to: validTestResult)!
+        
+        let calculatedValidFrom = Calendar.current.date(byAdding: DateComponents(day: 10), to: validTestResult)!
+        
+    
+        let trueValidFrom = dateFormatter.date(from: "2021-05-18")!
+        let dayBeforeValidFrom = Calendar.current.date(byAdding: DateComponents(day:-1), to: trueValidFrom)!
+        let trueValidUntil = dateFormatter.date(from: "2021-11-03")!
+        let dayAfterTrueValidUntil = dateFormatter.date(from: "2021-12-03")!
+        
+        // before validFrom it fails
+        // certificate has entry trueValidFrom
+        // today is dayBeforeValidFrom
+        XCTAssertTrue(trueValidFrom.isAfter(dayBeforeValidFrom))
+        
+        // at trueValidFrom it succeeds
+        // certificate has entry calculatedValidFrom
+        // today is trueValidFrom
+        XCTAssertFalse(calculatedValidFrom.isAfter(trueValidFrom))
+        
+        // at trueValidUntil it succeeds
+        // certificate has entry calculatedValidUntil
+        // today is trueValidUntil
+        XCTAssertFalse(calculatedValidUntil.isBefore(trueValidUntil))
+        
+        
+        // calculated valid from should match
+        XCTAssertTrue(calculatedValidFrom == trueValidFrom)
+        // calculated valid until should match
+        XCTAssertTrue(calculatedValidUntil == trueValidUntil)
+        
+        //the certificate is not valid one day after trueValidUntil
+        // certificate has entry calculatedValidUntil
+        // today is dayAfterTrueValidUntil
+        XCTAssertTrue(calculatedValidUntil.isBefore(dayAfterTrueValidUntil))
+       
+    }
 
     func testCertificateIsValidFor180DaysAfterTestResult() {
-        // The certificate was issued 179 days ago, which means it is still valid today
+        // The certificate was issued 179 days ago, which means it is still valid today (the 180th day)
         let hcert = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -179), tg: Disease.SarsCov2.rawValue)
         verifier.checkNationalRules(dgc: hcert) { result in
             switch result {
@@ -509,7 +555,7 @@ final class CovidCertificateSDKTests: XCTestCase {
                 XCTAssertTrue(false)
             }
         }
-        // the certificate should not be valid anymore, since it was issued yesterday 179 days ago (hence now it is 180 day ago)
+        // the certificate should not be valid anymore, since it was issued yesterday 179 days ago (hence yesterday was the 180th day)
         let hcert_invalid = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -180), tg: Disease.SarsCov2.rawValue)
         verifier.checkNationalRules(dgc: hcert_invalid) { result in
             switch result {

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -505,9 +505,9 @@ final class CovidCertificateSDKTests: XCTestCase {
         }
       
         let validTestResult = dateFormatter.date(from: "2021-05-08")!
-        let calculatedValidUntil = Calendar.current.date(byAdding: DateComponents(day: 179), to: validTestResult)!
+        let calculatedValidUntil = Calendar.current.date(byAdding: DateComponents(day: MAXIMUM_VALIDITY_IN_DAYS), to: validTestResult)!
         
-        let calculatedValidFrom = Calendar.current.date(byAdding: DateComponents(day: 10), to: validTestResult)!
+        let calculatedValidFrom = Calendar.current.date(byAdding: DateComponents(day: INFECTION_VALIDITY_OFFSET_IN_DAYS), to: validTestResult)!
         
     
         let trueValidFrom = dateFormatter.date(from: "2021-05-18")!

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -499,7 +499,7 @@ final class CovidCertificateSDKTests: XCTestCase {
 
     func testCertificateIsValidFor180DaysAfterTestResult() {
         // The certificate was issued 180 days ago, which means it is still valid today
-        let hcert = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -180), tg: Disease.SarsCov2.rawValue)
+        let hcert = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -179), tg: Disease.SarsCov2.rawValue)
         verifier.checkNationalRules(dgc: hcert) { result in
             switch result {
             case let .success(r):
@@ -510,7 +510,7 @@ final class CovidCertificateSDKTests: XCTestCase {
             }
         }
         // the certificate should not be valid anymore, since it was issued yesterday 180 days ago (hence now it is 181 day ago)
-        let hcert_invalid = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -181), tg: Disease.SarsCov2.rawValue)
+        let hcert_invalid = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -180), tg: Disease.SarsCov2.rawValue)
         verifier.checkNationalRules(dgc: hcert_invalid) { result in
             switch result {
             case let .success(r):

--- a/Tests/CovidCertificateSDKTests/DateTests.swift
+++ b/Tests/CovidCertificateSDKTests/DateTests.swift
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import XCTest
+@testable import CovidCertificateSDK
+
+final class DateTests: XCTestCase {
+    
+    func testISO8601Formatter() {
+        let iso8601WithoutTime = "2021-06-07"
+        XCTAssertNotNil(Date.fromISO8601(iso8601WithoutTime))
+
+        let iso8601WithSeconds = "2021-05-25T09:16:48Z"
+        XCTAssertNotNil(Date.fromISO8601(iso8601WithSeconds))
+
+        let iso8601WithFractionals = "2021-05-25T09:16:48.063Z"
+        XCTAssertNotNil(Date.fromISO8601(iso8601WithFractionals))
+
+    }
+}


### PR DESCRIPTION
The validity date is always included. This means a certificate valid until the 31.05  does include the 31.05 itself, hence we need to adjust the validity to +179 (previously +180)