### PR TITLE
update swiftcbor to version with fixes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -21,11 +21,11 @@
       },
       {
         "package": "SwiftCBOR",
-        "repositoryURL": "https://github.com/unrelentingtech/SwiftCBOR",
+        "repositoryURL": "https://github.com/eu-digital-green-certificates/SwiftCBOR",
         "state": {
-          "branch": null,
-          "revision": "668c26fc3373d5f1bccbaad7665ca6048797e324",
-          "version": "0.4.3"
+          "branch": "master",
+          "revision": "b76024995f6909e4615f943c7a03268fd29778fc",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(name: "Gzip", url: "https://github.com/1024jp/GzipSwift", .upToNextMajor(from: "5.1.1")),
-        .package(url: "https://github.com/unrelentingtech/SwiftCBOR", .upToNextMajor(from: "0.4.3")),
+        .package(url: "https://github.com/eu-digital-green-certificates/SwiftCBOR", .branch("master")),
         .package(url: "https://github.com/ehn-digital-green-development/base45-swift", .branch("main")),
     ],
     targets: [


### PR DESCRIPTION
The main `SwiftCBOR` library has some problems with certain tagged values. Hence, we switched to the [EU](https://github.com/eu-digital-green-certificates/SwiftCBOR) fork, with which we can now handle tagged CBOR correctly (test case [`BE`](https://github.com/eu-digital-green-certificates/dgc-testdata/tree/main/BE).