### PR TITLE
Improve ISO8601 parsing extension

### DIFF
--- a/Sources/CovidCertificateSDK/Date.swift
+++ b/Sources/CovidCertificateSDK/Date.swift
@@ -29,6 +29,18 @@ extension Date {
             return d
         }
 
+        // nothing worked, try adding UTC timezone
+        
+        let formatter_without_timezone = ISO8601DateFormatter()
+        // Try to parse without fractional seconds
+        if let d = formatter_without_timezone.date(from: dateString + "Z") {
+            return d
+        }
+        
+        formatter_without_timezone.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = formatter_without_timezone.date(from: dateString + "Z") {
+            return d
+        }
         return nil
     }
 }

--- a/Sources/CovidCertificateSDK/Date.swift
+++ b/Sources/CovidCertificateSDK/Date.swift
@@ -24,7 +24,7 @@ extension Date {
         }
 
         // Retry with fraction
-        formatter.formatOptions = [.withFractionalSeconds]
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         if let d = formatter.date(from: dateString) {
             return d
         }

--- a/Tests/CovidCertificateSDKTests/DateTests.swift
+++ b/Tests/CovidCertificateSDKTests/DateTests.swift
@@ -15,13 +15,25 @@ final class DateTests: XCTestCase {
     
     func testISO8601Formatter() {
         let iso8601WithoutTime = "2021-06-07"
-        XCTAssertNotNil(Date.fromISO8601(iso8601WithoutTime))
+        // We do not accept this a ISO8601 timestamp since it contains no timezone information and no time of day.
+        XCTAssertNil(Date.fromISO8601(iso8601WithoutTime))
 
         let iso8601WithSeconds = "2021-05-25T09:16:48Z"
         XCTAssertNotNil(Date.fromISO8601(iso8601WithSeconds))
+        let comparisonIso8601WithSeconds = Calendar.current.date(from:DateComponents( timeZone: NSTimeZone(name: "UTC")! as TimeZone,year:2021,month: 5,day:25,hour: 9,minute: 16,second: 48,nanosecond: 0) )
+        XCTAssertEqual(comparisonIso8601WithSeconds!, Date.fromISO8601(iso8601WithSeconds)!)
 
         let iso8601WithFractionals = "2021-05-25T09:16:48.063Z"
         XCTAssertNotNil(Date.fromISO8601(iso8601WithFractionals))
-
+        let comparisonIso8601WithFractionals = Calendar.current.date(from: DateComponents(timeZone: NSTimeZone(name: "UTC")! as TimeZone, year:2021,month: 5,day:25,hour: 9,minute: 16,second: 48,nanosecond: 63_000_000))
+        XCTAssertEqual(comparisonIso8601WithFractionals, Date.fromISO8601(iso8601WithFractionals))
+        
+        let iso8601WithManyFractionals = "2021-05-27T10:56:50.482139Z"
+        XCTAssertNotNil(Date.fromISO8601(iso8601WithManyFractionals))
+        // precision while parsing is different than platform
+        let comparisonIso8601WithManyFractionalsSlightlyBefore = Calendar.current.date(from: DateComponents(timeZone: NSTimeZone(name: "UTC")! as TimeZone, year:2021,month: 5,day:27,hour: 10,minute: 56,second: 50,nanosecond: 482_000_000))
+        let comparisonIso8601WithManyFractionalsSlightlyAfter = Calendar.current.date(from: DateComponents(timeZone: NSTimeZone(name: "UTC")! as TimeZone, year:2021,month: 5,day:27,hour: 10,minute: 56,second: 50,nanosecond: 482_140_000))
+        XCTAssertTrue(comparisonIso8601WithManyFractionalsSlightlyBefore!.isBefore(Date.fromISO8601(iso8601WithManyFractionals)!))
+        XCTAssertTrue(comparisonIso8601WithManyFractionalsSlightlyAfter!.isAfter(Date.fromISO8601(iso8601WithManyFractionals)!))
     }
 }


### PR DESCRIPTION
Fix iso8601 DateTime parsing. Before it would parse fractional seconds and always return a date around 2000-01-01. Here we add the `withInternetDateTime` formatting option to actually parse the DateTime _with_ fractional seconds.

Further, the tests were adjusted to test if the parsing actually yields the expected DateTime.

NOTE:
As always we must be careful comparing floating point numbers. For know the `630ms` as fractional seconds seem to work, but the `482_139_000ns` don't. Hence, we check if the DateTime is within valid bounds.