### PR TITLE
Wrong number of certificates is a "signature" error

### DIFF
--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -101,13 +101,6 @@ public struct ChCovidCert {
             return .failure(.COSE_DESERIALIZATION_FAILED)
         }
 
-        // only exactly one certificate is allowed in v1 (one vaccine, one test or one recovery)
-        let certIdentifiers = cwt.euHealthCert.certIdentifiers().count
-
-        if certIdentifiers != 1 {
-            return .failure(.HCERT_IS_INVALID)
-        }
-
         return .success(DGCHolder(cwt: cwt, cose: cose, keyId: keyId))
     }
 
@@ -124,6 +117,14 @@ public struct ChCovidCert {
             if issuedAt.isAfter(Date()) {
                 completionHandler(.failure(.CWT_EXPIRED))
             }
+        }
+
+        // only exactly one certificate is allowed in v1 (one vaccine, one test or one recovery)
+        let certIdentifiers = cose.healthCert.certIdentifiers().count
+
+        if certIdentifiers != 1 {
+            completionHandler(.failure(.SIGNATURE_TYPE_INVALID))
+            return
         }
 
         trustList.key(for: cose.keyId) { result in

--- a/Sources/CovidCertificateSDK/ehn/ValidationError.swift
+++ b/Sources/CovidCertificateSDK/ehn/ValidationError.swift
@@ -21,6 +21,7 @@ public enum ValidationError: Error, Equatable {
     case KEY_CREATION_ERROR
     case KEYSTORE_ERROR(cause: String)
     case REVOKED
+    case SIGNATURE_TYPE_INVALID
 
     public var message: String {
         switch self {
@@ -37,6 +38,7 @@ public enum ValidationError: Error, Equatable {
         case .CWT_EXPIRED: return "The CWT expiary date has been reached"
         case .ISSUED_IN_FUTURE: return "The CWT was issued in the future"
         case .REVOKED: return "Certificate was revoked"
+        case .SIGNATURE_TYPE_INVALID: return "The certificate is not valid according to specification"
         }
     }
 
@@ -55,6 +57,7 @@ public enum ValidationError: Error, Equatable {
         case .CWT_EXPIRED: return "S|CWTE"
         case .ISSUED_IN_FUTURE: return ""
         case .REVOKED: return "R|REV"
+        case .SIGNATURE_TYPE_INVALID: return "S|TIV"
         }
     }
 }


### PR DESCRIPTION
We don't want to be too restrictive during decoding. Hence, we switch the block checking for exactly one type and one certificate to the `checkSignature` function. So we can decode and show the certificate contents, but will show an error to the user that the certificate (or rather the container) is not valid.