### PR TITLE
CertType: check for nil OR empty

### DIFF
--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -119,10 +119,7 @@ public struct ChCovidCert {
             }
         }
 
-        // only exactly one certificate is allowed in v1 (one vaccine, one test or one recovery)
-        let certIdentifiers = cose.healthCert.certIdentifiers().count
-
-        if certIdentifiers != 1 {
+        if cose.healthCert.certType == nil {
             completionHandler(.failure(.SIGNATURE_TYPE_INVALID))
             return
         }

--- a/Sources/CovidCertificateSDK/ehn/EuHealthCert.swift
+++ b/Sources/CovidCertificateSDK/ehn/EuHealthCert.swift
@@ -17,20 +17,19 @@ public struct EuHealthCert: Codable {
     public let tests: [Test]?
 
     public var certType: CertType? {
-        if let v = vaccinations, v.count > 0,
-           self.pastInfections == nil,
-           self.tests == nil {
+        if let v = vaccinations, v.count == 1,
+           self.pastInfections.isNilOrEmpty(),
+           self.tests.isNilOrEmpty() {
             return .vaccination
-        } else if let p = pastInfections, p.count > 0,
-                  self.tests == nil,
-                  self.vaccinations == nil {
+        } else if let p = pastInfections, p.count == 1,
+                  self.tests.isNilOrEmpty(),
+                  self.vaccinations.isNilOrEmpty() {
             return .recovery
-        } else if let tests = self.tests, tests.count > 0,
-                  self.pastInfections == nil,
-                  self.vaccinations == nil {
+        } else if let tests = self.tests, tests.count == 1,
+                  self.pastInfections.isNilOrEmpty(),
+                  self.vaccinations.isNilOrEmpty() {
             return .test
         }
-
         return nil
     }
 

--- a/Sources/CovidCertificateSDK/ehn/Extensions.swift
+++ b/Sources/CovidCertificateSDK/ehn/Extensions.swift
@@ -27,6 +27,15 @@ extension Data {
     }
 }
 
+extension Optional where Wrapped: Collection {
+    /// Check if this optional array is nil or empty
+    func isNilOrEmpty() -> Bool{
+        // if self is nil `self?.isEmpty` is nil and hence the value after the ?? operator is used
+        // otherwise self!.isEmpty checks for an empty array
+        return self?.isEmpty ?? true
+    }
+}
+
 extension Date {
     func isBefore(_ otherDate: Date) -> Bool {
         self < otherDate


### PR DESCRIPTION
We now check for nil OR empty as some payloads contained an empty list instead of `nil`.

Further, we now check during the check for the certificate type, if the array only contains one entry (instead of using two functions).