### PR TITLE
Add missing return statements after completionHandler is called

### DIFF
--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -110,12 +110,14 @@ public struct ChCovidCert {
             let expireDate = Date(timeIntervalSince1970: Double(expiryTimestamp))
             if expireDate.isBefore(Date()) {
                 completionHandler(.failure(.CWT_EXPIRED))
+                return
             }
         }
         if let issuedAtTimestamp = cose.cwt.iat {
             let issuedAt = Date(timeIntervalSince1970: Double(issuedAtTimestamp))
             if issuedAt.isAfter(Date()) {
                 completionHandler(.failure(.CWT_EXPIRED))
+                return
             }
         }
 


### PR DESCRIPTION
This pull-request amends missing return statements to the CWT expiry handling, to make sure the completionHandler() is only called once.