### PR TITLE
Handle int,float and double values when decoding exp and iat

### DIFF
--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -111,7 +111,7 @@ public struct ChCovidCert {
         }
 
         if cose.healthCert.certType == nil {
-            completionHandler(.failure(.SIGNATURE_TYPE_INVALID))
+            completionHandler(.failure(.SIGNATURE_TYPE_INVALID(.CERT_TYPE_AMBIGUOUS)))
             return
         }
 

--- a/Sources/CovidCertificateSDK/ehn/CBORExtensions.swift
+++ b/Sources/CovidCertificateSDK/ehn/CBORExtensions.swift
@@ -29,6 +29,18 @@ extension CBOR {
         }
     }
 
+    func asNumericDate() -> Double? {
+        switch self {
+        case let .double(value): return Double(value)
+        case let .float(value): return Double(value)
+        case let .half(value): return Double(value)
+        case let .negativeInt(value): return Double(value)
+        case let .unsignedInt(value): return Double(value)
+        default:
+            return nil
+        }
+    }
+    
     func asUInt64() -> UInt64? {
         return unwrap() as? UInt64
     }

--- a/Sources/CovidCertificateSDK/ehn/CWT.swift
+++ b/Sources/CovidCertificateSDK/ehn/CWT.swift
@@ -28,7 +28,7 @@ public struct CWT {
         if let cwtExp = decodedPayload[PayloadKeys.exp]
         {
             guard let exp = cwtExp.asNumericDate() else {
-                return .failure(.SIGNATURE_TYPE_INVALID)
+                return .failure(.SIGNATURE_TYPE_INVALID(.CWT_HEADER_PARSE_ERROR))
             }
             let expireDate = Date(timeIntervalSince1970: exp)
             if expireDate.isBefore(now) {
@@ -39,7 +39,7 @@ public struct CWT {
         if let cwtIat = decodedPayload[PayloadKeys.iat]
         {
             guard let iat = cwtIat.asNumericDate() else {
-                return .failure(.SIGNATURE_TYPE_INVALID)
+                return .failure(.SIGNATURE_TYPE_INVALID(.CWT_HEADER_PARSE_ERROR))
             }
             let issuedAt = Date(timeIntervalSince1970: Double(iat))
             if issuedAt.isAfter(now) {

--- a/Sources/CovidCertificateSDK/ehn/CWT.swift
+++ b/Sources/CovidCertificateSDK/ehn/CWT.swift
@@ -10,9 +10,8 @@ import SwiftCBOR
 
 public struct CWT {
     let iss: String?
-    let exp: UInt64?
-    let iat: UInt64?
     let euHealthCert: EuHealthCert
+    let decodedPayload :  [CBOR: CBOR]
 
     enum PayloadKeys: Int {
         case iss = 1
@@ -24,14 +23,41 @@ public struct CWT {
             case euHealthCertV1 = 1
         }
     }
+    
+    func isValid(now: Date = Date()) -> Result<Bool, ValidationError> {
+        if let cwtExp = decodedPayload[PayloadKeys.exp]
+        {
+            guard let exp = cwtExp.asNumericDate() else {
+                return .failure(.SIGNATURE_TYPE_INVALID)
+            }
+            let expireDate = Date(timeIntervalSince1970: exp)
+            if expireDate.isBefore(now) {
+                return .success(false)
+            }
+        }
+        
+        if let cwtIat = decodedPayload[PayloadKeys.iat]
+        {
+            guard let iat = cwtIat.asNumericDate() else {
+                return .failure(.SIGNATURE_TYPE_INVALID)
+            }
+            let issuedAt = Date(timeIntervalSince1970: Double(iat))
+            if issuedAt.isAfter(now) {
+                return .success(false)
+            }
+        }
+        return .success(true)
+    }
 
     init?(from cbor: CBOR) {
-        guard let decodedPayload = cbor.decodeBytestring()?.asMap() else {
+        guard let decodedPayloadCwt = cbor.decodeBytestring()?.asMap() else {
             return nil
         }
+        decodedPayload = decodedPayloadCwt
+        
         iss = decodedPayload[PayloadKeys.iss]?.asString()
-        exp = decodedPayload[PayloadKeys.exp]?.asUInt64()
-        iat = decodedPayload[PayloadKeys.iat]?.asUInt64()
+
+        
         guard let hCertMap = decodedPayload[PayloadKeys.hcert]?.asMap(),
               let certData = hCertMap[PayloadKeys.HcertKeys.euHealthCertV1]?.asData(),
               let healthCert = try? CodableCBORDecoder().decode(EuHealthCert.self, from: certData) else {

--- a/Sources/CovidCertificateSDK/ehn/ValidationError.swift
+++ b/Sources/CovidCertificateSDK/ehn/ValidationError.swift
@@ -7,6 +7,25 @@
 
 import Foundation
 
+
+public enum SignatureTypeInvalidError: Error, Equatable {
+    case CWT_HEADER_PARSE_ERROR
+    case CERT_TYPE_AMBIGUOUS
+    
+    public var message: String {
+        switch self {
+        case .CERT_TYPE_AMBIGUOUS: return "The certificate type could not be determined"
+        case.CWT_HEADER_PARSE_ERROR: return "The CWT exp/iat headers could not be parsed"
+        }
+    }
+    public var errorCode: String {
+        switch self {
+        case .CERT_TYPE_AMBIGUOUS: return "CTA"
+        case .CWT_HEADER_PARSE_ERROR: return "HPE"
+        }
+    }
+}
+
 public enum ValidationError: Error, Equatable {
     case GENERAL_ERROR
     case CBOR_DESERIALIZATION_FAILED
@@ -21,7 +40,7 @@ public enum ValidationError: Error, Equatable {
     case KEY_CREATION_ERROR
     case KEYSTORE_ERROR(cause: String)
     case REVOKED
-    case SIGNATURE_TYPE_INVALID
+    case SIGNATURE_TYPE_INVALID(SignatureTypeInvalidError)
 
     public var message: String {
         switch self {
@@ -57,7 +76,7 @@ public enum ValidationError: Error, Equatable {
         case .CWT_EXPIRED: return "S|CWTE"
         case .ISSUED_IN_FUTURE: return ""
         case .REVOKED: return "R|REV"
-        case .SIGNATURE_TYPE_INVALID: return "S|TIV"
+        case let .SIGNATURE_TYPE_INVALID(wrapped): return "S|TIV|" + wrapped.errorCode
         }
     }
 }


### PR DESCRIPTION
When decoding the CWT the `exp` and `iat` headers are tried to be parsed as either a uint, int, float or double. 
If the decoding fails, we throw a `SignatureInvalid` error, instead of ignoring it.