### PR TITLE
Fix `validDuration` of active key list

### DIFF
--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -49,8 +49,6 @@ class TrustCertificatesUpdate: TrustListUpdate {
             return .NETWORK_PARSE_ERROR
         }
 
-        _ = trustStorage.updateActiveCertificates(result)
-
         // update trust certificates service
         var listNeedsUpdate = true
         var requestsCount = 0
@@ -100,6 +98,10 @@ class TrustCertificatesUpdate: TrustListUpdate {
             // start another request, as long as certificates are coming in
             listNeedsUpdate = upToDate == Self.falseConstant
         }
+
+        // Check which certificates need to be removed. This needs to be called
+        // after loading new certificates and only if it was successful.
+        _ = trustStorage.updateActiveCertificates(result)
 
         return nil
     }

--- a/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
@@ -93,6 +93,7 @@ class TrustStorage: TrustStorageProtocol {
             }
 
             Self.sharedStorage.lastCertificateListDownload = Int64(Date().timeIntervalSince1970 * 1000.0)
+            Self.sharedStorage.certificateValidDuration = activeCertificates.validDuration
 
             return Self.secureStorage.saveSynchronously(Self.sharedStorage)
         }


### PR DESCRIPTION
This pull-request makes sure we store the `validDuration` of the active key request in sharedStorage. It also changes the order of the update mechanism, to make sure we only update `validDuration` after we've successfully loaded new certificates.