### PR TITLE
Improve performance while checking rules

### DIFF
--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -169,8 +169,8 @@ public struct ChCovidCert {
                 let list = self.trustListManager.trustStorage.nationalRules()
 
                 guard let certLogic = CertLogic(),
-                      let valueSets = list.getValueSetsJSON(),
-                      let rules = list.getRulesJSON()
+                      let valueSets = list.valueSets,
+                      let rules = list.rules
                 else {
                     completionHandler(.failure(.NETWORK_PARSE_ERROR))
                     return

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
@@ -14,21 +14,20 @@ import JSON
 
 public class NationalRulesList: Codable, JWTExtension {
     public var validDuration: Int64 = 0
-    public var requestData: Data? = nil
-
-    public func getRulesJSON() -> JSON? {
-        guard let rulesData = requestData else {
-            return nil
+    public var requestData: Data? {
+        didSet {
+            if let newValue = requestData {
+                rules = JSON(newValue)["rules"]
+                valueSets = JSON(newValue)["valueSets"]
+            } else {
+                rules = nil
+                valueSets = nil
+            }
         }
-        return JSON(rulesData)["rules"]
     }
 
-    public func getValueSetsJSON() -> JSON? {
-        guard let rulesData = requestData else {
-            return nil
-        }
-        return JSON(rulesData)["valueSets"]
-    }
+    var rules: JSON? = nil
+    var valueSets: JSON? = nil
 
     enum CodingKeys: String, CodingKey {
         case validDuration


### PR DESCRIPTION
Before each time the rules were checked, we deserialized `requestData`. 
Now we deserialize it once when set.