### PR TITLE
Fix problem that rules and valueSets are not set during init

### DIFF
--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
@@ -41,7 +41,7 @@ public class NationalRulesList: Codable, JWTExtension {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         validDuration = try container.decode(Int64.self, forKey: .validDuration)
         requestData = try? container.decode(Data.self, forKey: .requestData)
-        
+
         if let newValue = requestData {
             rules = JSON(newValue)["rules"]
             valueSets = JSON(newValue)["valueSets"]

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
@@ -41,6 +41,11 @@ public class NationalRulesList: Codable, JWTExtension {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         validDuration = try container.decode(Int64.self, forKey: .validDuration)
         requestData = try? container.decode(Data.self, forKey: .requestData)
+        
+        if let newValue = requestData {
+            rules = JSON(newValue)["rules"]
+            valueSets = JSON(newValue)["valueSets"]
+        }
     }
 
     public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
During init not the property but the field is set, hence `didSet` is not called. This leads to problems, when deserializing a saved response from the storage.

We now try to parse rules and value sets if `requestData` is not null (hence it was deserialized from storage)