### PR TITLE
Fixes force update on app start

### DIFF
--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -230,7 +230,7 @@ public struct ChCovidCert {
                         completionHandler(.failure(.UNKNOWN_TEST_FAILURE))
                     }
                     return
-                case let .failure(.TEST_COULD_NOT_BE_PERFORMED(test)):
+                case let .failure(.TEST_COULD_NOT_BE_PERFORMED(_)):
                     completionHandler(.failure(.UNKNOWN_TEST_FAILURE))
                     return
                 default:

--- a/Sources/CovidCertificateSDK/Networking/Endpoint.swift
+++ b/Sources/CovidCertificateSDK/Networking/Endpoint.swift
@@ -28,9 +28,13 @@ struct Endpoint {
 }
 
 extension Endpoint {
-    func request(timeoutInterval: TimeInterval = 30.0) -> URLRequest {
+    func request(timeoutInterval: TimeInterval = 30.0, reloadIgnoringLocalCache: Bool = false) -> URLRequest {
         var request = URLRequest(url: url, timeoutInterval: timeoutInterval)
         request.httpMethod = method.rawValue
+
+        if reloadIgnoringLocalCache {
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+        }
 
         request.setValue(userAgentHeader, forHTTPHeaderField: "User-Agent")
 

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
@@ -19,8 +19,8 @@ class NationalRulesListUpdate: TrustListUpdate {
 
     // MARK: - Update
 
-    override internal func synchronousUpdate() -> NetworkError? {
-        let request = CovidCertificateSDK.currentEnvironment.nationalRulesListService.request()
+    override internal func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
+        let request = CovidCertificateSDK.currentEnvironment.nationalRulesListService.request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (data, _, error) = session.synchronousDataTask(with: request)
 
         if error != nil {

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -18,9 +18,9 @@ class RevocationListUpdate: TrustListUpdate {
 
     // MARK: - Update
 
-    override internal func synchronousUpdate() -> NetworkError? {
+    override internal func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         // download data and update local storage
-        let request = CovidCertificateSDK.currentEnvironment.revocationListService.request()
+        let request = CovidCertificateSDK.currentEnvironment.revocationListService.request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (data, _, error) = session.synchronousDataTask(with: request)
 
         if error != nil {

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -22,9 +22,9 @@ class TrustCertificatesUpdate: TrustListUpdate {
 
     // MARK: - Update
 
-    override internal func synchronousUpdate() -> NetworkError? {
+    override internal func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         // update active certificates service
-        let requestActive = CovidCertificateSDK.currentEnvironment.activeCertificatesService.request()
+        let requestActive = CovidCertificateSDK.currentEnvironment.activeCertificatesService.request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (dataActive, _, errorActive) = session.synchronousDataTask(with: requestActive)
 
         if errorActive != nil {
@@ -56,7 +56,7 @@ class TrustCertificatesUpdate: TrustListUpdate {
         while listNeedsUpdate, requestsCount < Self.maximumNumberOfRequests {
             requestsCount = requestsCount + 1
 
-            let request = CovidCertificateSDK.currentEnvironment.trustCertificatesService(since: trustStorage.certificateSince()).request()
+            let request = CovidCertificateSDK.currentEnvironment.trustCertificatesService(since: trustStorage.certificateSince()).request(reloadIgnoringLocalCache: ignoreLocalCache)
             let (data, response, error) = session.synchronousDataTask(with: request)
 
             if error != nil {

--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -111,6 +111,7 @@ public class TrustListUpdate {
         // ensures that the update request is done before the other tasks
         self.trustStorage = trustStorage
         operationQueue.maxConcurrentOperationCount = 1
+        forceUpdateQueue.maxConcurrentOperationCount = 1
     }
 
     public func forceUpdate(completion: @escaping (() -> Void)) {
@@ -152,7 +153,7 @@ public class TrustListUpdate {
 
     // MARK: - Update
 
-    internal func synchronousUpdate() -> NetworkError? {
+    internal func synchronousUpdate(ignoreLocalCache _: Bool = false) -> NetworkError? {
         // download data and update local storage
         return nil
     }
@@ -162,12 +163,12 @@ public class TrustListUpdate {
     }
 
     private func startUpdate() {
-        lastError = synchronousUpdate()
-
+        lastError = synchronousUpdate(ignoreLocalCache: true)
         updateOperation = nil
     }
 
     private func startForceUpdate() {
-        _ = synchronousUpdate()
+        _ = synchronousUpdate(ignoreLocalCache: true)
+        forceUpdateOperation = nil
     }
 }

--- a/Sources/CovidCertificateSDK/ehn/SecureStorage/SecureStorage.swift
+++ b/Sources/CovidCertificateSDK/ehn/SecureStorage/SecureStorage.swift
@@ -39,10 +39,15 @@ public struct SecureStorage<T: Codable> {
         appropriateFor: nil,
         create: true
     )
-    var path: URL! { URL(string: documents.absoluteString + "secure.db") }
-    let secureStorageKey = Enclave.loadOrGenerateKey(with: "secureStorageKey")
+    var path: URL! { URL(string: documents.absoluteString + name) }
+    let secureStorageKey: SecKey?
 
-    public init() {}
+    let name: String
+
+    public init(name: String) {
+        self.name = name
+        secureStorageKey = Enclave.loadOrGenerateKey(with: "\(name)_secureStorageKey")
+    }
 
     /**
      Loads encrypted db and overrides it with an empty one if that fails.

--- a/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
+++ b/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
@@ -62,7 +62,7 @@ class TestTrustlistManager: TrustlistManagerProtocol {
 class TestTrustListUpdate: TrustListUpdate {
     // MARK: - Update
 
-    override internal func synchronousUpdate() -> NetworkError? {
+    override internal func synchronousUpdate(ignoreLocalCache _: Bool = false) -> NetworkError? {
         // update active certificates service
         sleep(1)
         return nil


### PR DESCRIPTION
- divides trust storage databases in three section (revocation, active certificates, national rules)
- fixes force update queue
- ignores local cache data for requesting