### PR TITLE
Improve offline mode

### DIFF
--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -137,20 +137,20 @@ public class TrustListUpdate {
             let updateNeeeded = !self.isListStillValid() || forceUpdate
             let updateAlreadyRunnning = self.updateOperation != nil
 
-        if updateNeeeded, !updateAlreadyRunnning {
+            if updateNeeeded, !updateAlreadyRunnning {
                 self.updateOperation = BlockOperation(block: { [weak self] in
-                guard let strongSelf = self else { return }
-                strongSelf.startUpdate()
-            })
+                    guard let strongSelf = self else { return }
+                    strongSelf.startUpdate()
+                })
 
-            // !: initialized just above
+                // !: initialized just above
                 self.operationQueue.addOperation(self.updateOperation!)
-        }
+            }
 
             self.operationQueue.addOperation {
-            checkOperation(self.lastError)
+                checkOperation(self.lastError)
+            }
         }
-    }
     }
 
     // MARK: - Update
@@ -170,7 +170,13 @@ public class TrustListUpdate {
     }
 
     private func startForceUpdate() {
-        _ = synchronousUpdate(ignoreLocalCache: true)
+        let error = synchronousUpdate(ignoreLocalCache: true)
+        // Only reset lastError if synchronousUpdate was successful
+        if error == nil {
+            operationQueue.addOperation {
+                self.lastError = nil
+            }
+        }
         forceUpdateOperation = nil
     }
 }

--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -133,22 +133,24 @@ public class TrustListUpdate {
     }
 
     public func addCheckOperation(forceUpdate: Bool, checkOperation: @escaping ((NetworkError?) -> Void)) {
-        let updateNeeeded = !isListStillValid() || forceUpdate
-        let updateAlreadyRunnning = updateOperation != nil
+        DispatchQueue.global().async {
+            let updateNeeeded = !self.isListStillValid() || forceUpdate
+            let updateAlreadyRunnning = self.updateOperation != nil
 
         if updateNeeeded, !updateAlreadyRunnning {
-            updateOperation = BlockOperation(block: { [weak self] in
+                self.updateOperation = BlockOperation(block: { [weak self] in
                 guard let strongSelf = self else { return }
                 strongSelf.startUpdate()
             })
 
             // !: initialized just above
-            operationQueue.addOperation(updateOperation!)
+                self.operationQueue.addOperation(self.updateOperation!)
         }
 
-        operationQueue.addOperation {
+            self.operationQueue.addOperation {
             checkOperation(self.lastError)
         }
+    }
     }
 
     // MARK: - Update


### PR DESCRIPTION
This pull-request fixes the following problems:
- Make sure to load/initialize trust storage synchronously (otherwise verification operations already try to read from it before it was initialised)
- Put `addCheckOperation` on a background queue to avoid `isListStillValid` blocking main queue
- Reset `lastError` if pro-active (force-)update request was successful (this fixes the problem that the app stayed in "offline mode" even though the list was successfully refreshed.