### PR TITLE
Feature: Allow to disable certificate pinning

### DIFF
--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -63,7 +63,6 @@ public struct DGCHolder {
         self.keyId = keyId
     }
 
-    @available(OSX 10.13, *)
     public func hasValidSignature(for publicKey: SecKey) -> Bool {
         cose.hasValidSignature(for: publicKey)
     }
@@ -109,7 +108,6 @@ public struct ChCovidCert {
         return .success(DGCHolder(cwt: cwt, cose: cose, keyId: keyId))
     }
 
-    @available(OSX 10.13, *)
     public func checkSignature(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
         switch cose.cwt.isValid() {
         case let .success(isValid):
@@ -140,7 +138,6 @@ public struct ChCovidCert {
     }
 
     public func checkRevocationStatus(dgc: EuHealthCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
-        // As long as no revocation list is published yet, return true
         trustListManager.revocationListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { error in
 
             if let e = error?.asValidationError() {

--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -27,7 +27,6 @@ public enum CovidCertificateSDK {
         return instance.decode(encodedData: encodedData)
     }
 
-    @available(OSX 10.13, *)
     public static func checkSignature(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
         instancePrecondition()
         return instance.checkSignature(cose: cose, forceUpdate: forceUpdate, completionHandler)

--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -61,4 +61,8 @@ public enum CovidCertificateSDK {
         instancePrecondition()
         return instance.apiKey
     }
+
+    public static func setOptions(options: SDKOptions) {
+        URLSession.evaluator.useCertificatePinning = options.certificatePinning
+    }
 }

--- a/Sources/CovidCertificateSDK/Networking/UBPinnedCertificatesTrustEvaluator.swift
+++ b/Sources/CovidCertificateSDK/Networking/UBPinnedCertificatesTrustEvaluator.swift
@@ -121,18 +121,16 @@ public final class UBPinnedCertificatesTrustEvaluator: UBServerTrustEvaluator {
     }
 }
 
-#if DEBUG || ENABLE_TESTING
-    /// Disables all evaluation which in turn will always consider any server trust as valid.
-    ///
-    /// THIS EVALUATOR SHOULD NEVER BE USED IN PRODUCTION!
-    public final class UBDisabledEvaluator: UBServerTrustEvaluator {
-        /// :nodoc:
-        public init() {}
+/// Disables all evaluation which in turn will always consider any server trust as valid.
+///
+/// THIS EVALUATOR SHOULD NEVER BE USED IN PRODUCTION!
+public final class UBDisabledEvaluator: UBServerTrustEvaluator {
+    /// :nodoc:
+    public init() {}
 
-        /// :nodoc:
-        public func evaluate(_: SecTrust, forHost _: String) throws {}
-    }
-#endif
+    /// :nodoc:
+    public func evaluate(_: SecTrust, forHost _: String) throws {}
+}
 
 extension Bundle {
     /// Returns all valid `cer`, `crt`, and `der` certificates in the bundle.

--- a/Sources/CovidCertificateSDK/Networking/URLSession+pinning.swift
+++ b/Sources/CovidCertificateSDK/Networking/URLSession+pinning.swift
@@ -24,59 +24,36 @@ extension URLSession {
 
 class CertificateEvaluator: NSObject, URLSessionDelegate {
     typealias AuthenticationChallengeCompletion = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
-    #if ENABLE_TESTING
-        private var trustManager: UBServerTrustManager
-    #else
-        private let trustManager: UBServerTrustManager
-    #endif
 
-    #if ENABLE_TESTING
-        private let useCertificatePinningKey = "useCertificatePinning"
+    private var trustManager: UBServerTrustManager
 
-        @UBUserDefault(key: "useCertificatePinning", defaultValue: true)
-        private(set) static var useCertificatePinning: Bool
+    private(set) static var useCertificatePinning: Bool = true
 
-        var useCertificatePinning: Bool {
-            get {
-                Self.useCertificatePinning
-            }
-            set {
-                Self.useCertificatePinning = newValue
-                if newValue {
-                    trustManager = Self.getServerTrustManager()
-                } else {
-                    trustManager = Self.getEmptyServerTrustManager()
-                }
+    var useCertificatePinning: Bool {
+        get {
+            Self.useCertificatePinning
+        }
+        set {
+            Self.useCertificatePinning = newValue
+            if newValue {
+                trustManager = Self.getServerTrustManager()
+            } else {
+                trustManager = Self.getEmptyServerTrustManager()
             }
         }
-
-    #elseif DEBUG
-        private static let useCertificatePinning = true
-    #endif
-
-    override init() {
-        #if ENABLE_TESTING
-            if Self.useCertificatePinning {
-                trustManager = Self.getServerTrustManager()
-            } else {
-                trustManager = Self.getEmptyServerTrustManager()
-            }
-        #elseif DEBUG
-            if CertificateEvaluator.useCertificatePinning {
-                trustManager = Self.getServerTrustManager()
-            } else {
-                trustManager = Self.getEmptyServerTrustManager()
-            }
-        #else
-            trustManager = Self.getServerTrustManager()
-        #endif
     }
 
-    #if DEBUG || ENABLE_TESTING
-        private static func getEmptyServerTrustManager() -> UBServerTrustManager {
-            UBServerTrustManager(evaluators: [:], default: UBDisabledEvaluator())
+    override init() {
+        if Self.useCertificatePinning {
+            trustManager = Self.getServerTrustManager()
+        } else {
+            trustManager = Self.getEmptyServerTrustManager()
         }
-    #endif
+    }
+
+    private static func getEmptyServerTrustManager() -> UBServerTrustManager {
+        UBServerTrustManager(evaluators: [:], default: UBDisabledEvaluator())
+    }
 
     private static func getServerTrustManager() -> UBServerTrustManager {
         var evaluators: [String: UBServerTrustEvaluator] = [:]

--- a/Sources/CovidCertificateSDK/SDKOptions.swift
+++ b/Sources/CovidCertificateSDK/SDKOptions.swift
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Foundation
+
+/// Configure advanced options of the SDK
+public struct SDKOptions {
+
+    /// Option to disable certificate pinning of TLS requests for debugging
+    var certificatePinning = true
+
+    public init(certificatePinning: Bool) {
+        self.certificatePinning = certificatePinning
+    }
+}

--- a/Sources/CovidCertificateSDK/SDKOptions.swift
+++ b/Sources/CovidCertificateSDK/SDKOptions.swift
@@ -12,7 +12,6 @@ import Foundation
 
 /// Configure advanced options of the SDK
 public struct SDKOptions {
-
     /// Option to disable certificate pinning of TLS requests for debugging
     var certificatePinning = true
 


### PR DESCRIPTION
This pull-request adds an option to disable certificate pinning in the SDK to facilitate debugging. This should not be used in production.