### PR TITLE
Feature: SDK API cleanup

### DIFF
--- a/Sources/CovidCertificateSDK/CertLogic/CertLogic.swift
+++ b/Sources/CovidCertificateSDK/CertLogic/CertLogic.swift
@@ -12,17 +12,17 @@ import Foundation
 import JSON
 import jsonlogic
 
-public enum CertLogicCommonError: String, Error {
+enum CertLogicCommonError: String, Error {
     case RULE_PARSING_FAILED
 }
 
-public enum CertLogicValidationError: Error {
+enum CertLogicValidationError: Error {
     case JSON_ERROR
     case TESTS_FAILED(tests: [String: String])
     case TEST_COULD_NOT_BE_PERFORMED(test: String)
 }
 
-public class CertLogic {
+class CertLogic {
     private static let acceptanceCriteriaKey: String = "acceptance-criteria"
     private static let vaccineImmunityKey: String = "vaccine-immunity"
     private static let singleVaccineValidityOffsetKey: String = "single-vaccine-validity-offset"
@@ -35,12 +35,12 @@ public class CertLogic {
     var valueSets: JSON = []
     let calendar: Calendar
 
-    public var maxValidity: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.vaccineImmunityKey].int }
-    public var daysAfterFirstShot: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.singleVaccineValidityOffsetKey].int }
-    public var pcrValidity: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.pcrTestValidityKey].int }
-    public var ratValidity: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.ratTestValidityKey].int }
+    var maxValidity: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.vaccineImmunityKey].int }
+    var daysAfterFirstShot: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.singleVaccineValidityOffsetKey].int }
+    var pcrValidity: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.pcrTestValidityKey].int }
+    var ratValidity: Int64? { valueSets[CertLogic.acceptanceCriteriaKey][CertLogic.ratTestValidityKey].int }
 
-    public init?() {
+    init?() {
         guard let utc = TimeZone(identifier: "UTC") else {
             return nil
         }
@@ -49,7 +49,7 @@ public class CertLogic {
         calendar = tmpCalendar
     }
 
-    public func updateData(rules: JSON, valueSets: JSON) -> Result<Void, CertLogicCommonError> {
+    func updateData(rules: JSON, valueSets: JSON) -> Result<Void, CertLogicCommonError> {
         guard let array = rules.array else {
             return .failure(.RULE_PARSING_FAILED)
         }
@@ -58,7 +58,7 @@ public class CertLogic {
         return .success(())
     }
 
-    public func checkRules(hcert: EuHealthCert, validationClock: Date = Date()) -> Result<Void, CertLogicValidationError> {
+    func checkRules(hcert: EuHealthCert, validationClock: Date = Date()) -> Result<Void, CertLogicValidationError> {
         var external = JSON(
             ["validationClock": ISO8601DateFormatter().string(from: validationClock),
              "validationClockAtStartOfDay": ISO8601DateFormatter().string(from: calendar.startOfDay(for: validationClock))]

--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -68,14 +68,14 @@ public struct DGCHolder {
     }
 }
 
-public struct ChCovidCert {
+struct ChCovidCert {
     private let PREFIX = "HC1:"
 
     private let trustListManager: TrustlistManagerProtocol
     private let nationalRules = NationalRulesVerifier()
 
-    public let environment: SDKEnvironment
-    public let apiKey: String
+    let environment: SDKEnvironment
+    let apiKey: String
 
     init(environment: SDKEnvironment, apiKey: String, trustListManager: TrustlistManagerProtocol) {
         self.environment = environment
@@ -83,7 +83,7 @@ public struct ChCovidCert {
         self.trustListManager = trustListManager
     }
 
-    public func decode(encodedData: String) -> Result<DGCHolder, CovidCertError> {
+    func decode(encodedData: String) -> Result<DGCHolder, CovidCertError> {
         #if DEBUG
             print(encodedData)
         #endif
@@ -108,7 +108,7 @@ public struct ChCovidCert {
         return .success(DGCHolder(cwt: cwt, cose: cose, keyId: keyId))
     }
 
-    internal func check(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (CheckResults) -> Void) {
+    func check(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (CheckResults) -> Void) {
 
         let group = DispatchGroup()
 
@@ -148,7 +148,7 @@ public struct ChCovidCert {
         }
     }
 
-    internal func checkSignature(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
+    func checkSignature(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
         switch cose.cwt.isValid() {
         case let .success(isValid):
             if !isValid {
@@ -177,7 +177,7 @@ public struct ChCovidCert {
         })
     }
 
-    public func checkRevocationStatus(dgc: EuHealthCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
+    func checkRevocationStatus(dgc: EuHealthCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
         trustListManager.revocationListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { error in
 
             if let e = error?.asValidationError() {
@@ -192,7 +192,7 @@ public struct ChCovidCert {
         })
     }
 
-    public func checkNationalRules(dgc: EuHealthCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
+    func checkNationalRules(dgc: EuHealthCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
         if dgc.certType == nil {
             completionHandler(.failure(.NO_VALID_PRODUCT))
             return
@@ -267,7 +267,7 @@ public struct ChCovidCert {
                         completionHandler(.failure(.UNKNOWN_TEST_FAILURE))
                     }
                     return
-                case let .failure(.TEST_COULD_NOT_BE_PERFORMED(_)):
+                case .failure(.TEST_COULD_NOT_BE_PERFORMED(_)):
                     completionHandler(.failure(.UNKNOWN_TEST_FAILURE))
                     return
                 default:
@@ -278,7 +278,7 @@ public struct ChCovidCert {
         })
     }
 
-    public func restartTrustListUpdate(completionHandler: @escaping () -> Void, updateTimeInterval: TimeInterval) {
+    func restartTrustListUpdate(completionHandler: @escaping () -> Void, updateTimeInterval: TimeInterval) {
         trustListManager.restartTrustListUpdate(completionHandler: completionHandler, updateTimeInterval: updateTimeInterval)
     }
 
@@ -287,7 +287,7 @@ public struct ChCovidCert {
     }
 
     /// Strips a given scheme prefix from the encoded EHN health certificate
-    private func removeScheme(prefix: String, from encodedString: String) -> String? {
+    func removeScheme(prefix: String, from encodedString: String) -> String? {
         guard encodedString.starts(with: prefix) else {
             return nil
         }
@@ -295,17 +295,17 @@ public struct ChCovidCert {
     }
 
     /// Base45-decodes an EHN health certificate
-    private func decode(_ encodedData: String) -> Data? {
+    func decode(_ encodedData: String) -> Data? {
         return try? encodedData.fromBase45()
     }
 
     /// Decompress the EHN health certificate using ZLib
-    private func decompress(_ encodedData: Data) -> Data? {
+    func decompress(_ encodedData: Data) -> Data? {
         return try? encodedData.gunzipped()
     }
 
     /// Creates COSE structure from EHN health certificate
-    private func cose(from data: Data) -> Cose? {
+    func cose(from data: Data) -> Cose? {
         return Cose(from: data)
     }
 }

--- a/Sources/CovidCertificateSDK/ChCovidCert.swift
+++ b/Sources/CovidCertificateSDK/ChCovidCert.swift
@@ -109,7 +109,6 @@ struct ChCovidCert {
     }
 
     func check(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (CheckResults) -> Void) {
-
         let group = DispatchGroup()
 
         var signatureResult: Result<ValidationResult, ValidationError>?

--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -22,24 +22,38 @@ public enum CovidCertificateSDK {
         instance = ChCovidCert(environment: environment, apiKey: apiKey, trustListManager: TrustlistManager())
     }
 
-    public static func decode(encodedData: String) -> Result<DGCHolder, CovidCertError> {
-        instancePrecondition()
-        return instance.decode(encodedData: encodedData)
+    public enum Verifier {
+
+        public static func decode(encodedData: String) -> Result<DGCVerifierHolder, CovidCertError> {
+            instancePrecondition()
+            switch instance.decode(encodedData: encodedData) {
+            case let .success(dgc):
+                return .success(.init(dgc: dgc))
+            case let .failure(error):
+                return .failure(error)
+            }
+        }
+
+        public static func check(cose: DGCVerifierHolder, forceUpdate: Bool, _ completionHandler: @escaping (CheckResults) -> Void) {
+            instancePrecondition()
+            return instance.check(cose: cose.dgc, forceUpdate: forceUpdate, completionHandler)
+        }
+        
     }
 
-    public static func checkSignature(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
-        instancePrecondition()
-        return instance.checkSignature(cose: cose, forceUpdate: forceUpdate, completionHandler)
-    }
+    public enum Wallet {
 
-    public static func checkRevocationStatus(dgc: EuHealthCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
-        instancePrecondition()
-        return instance.checkRevocationStatus(dgc: dgc, forceUpdate: forceUpdate, completionHandler)
-    }
+        public static func decode(encodedData: String) -> Result<DGCHolder, CovidCertError> {
+            instancePrecondition()
+            return instance.decode(encodedData: encodedData)
+        }
 
-    public static func checkNationalRules(dgc: EuHealthCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
-        instancePrecondition()
-        return instance.checkNationalRules(dgc: dgc, forceUpdate: forceUpdate, completionHandler)
+
+        public static func check(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (CheckResults) -> Void) {
+            instancePrecondition()
+            return instance.check(cose: cose, forceUpdate: forceUpdate, completionHandler)
+        }
+
     }
 
     public static func restartTrustListUpdate(completionHandler: @escaping () -> Void, updateTimeInterval: TimeInterval) {

--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -36,7 +36,21 @@ public enum CovidCertificateSDK {
 
         public static func check(cose: DGCVerifierHolder, forceUpdate: Bool, _ completionHandler: @escaping (CheckResults) -> Void) {
             instancePrecondition()
-            return instance.check(cose: cose.dgc, forceUpdate: forceUpdate, completionHandler)
+            instance.check(cose: cose.dgc, forceUpdate: forceUpdate) { result in
+                switch result.nationalRules {
+                // only expose networking errors and the success case for verification apps
+                case .success,
+                     .failure(.NETWORK_NO_INTERNET_CONNECTION),
+                     .failure(.NETWORK_PARSE_ERROR),
+                     .failure(.NETWORK_ERROR):
+                    return completionHandler(result)
+                case .failure:
+                    // Strip specific national rules error for verification apps
+                    return completionHandler(.init(signature: result.signature,
+                                                   revocationStatus: result.revocationStatus,
+                                                   nationalRules: .failure(.UNKNOWN_TEST_FAILURE)))
+                }
+            }
         }
         
     }

--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -23,7 +23,6 @@ public enum CovidCertificateSDK {
     }
 
     public enum Verifier {
-
         public static func decode(encodedData: String) -> Result<DGCVerifierHolder, CovidCertError> {
             instancePrecondition()
             switch instance.decode(encodedData: encodedData) {
@@ -52,22 +51,18 @@ public enum CovidCertificateSDK {
                 }
             }
         }
-        
     }
 
     public enum Wallet {
-
         public static func decode(encodedData: String) -> Result<DGCHolder, CovidCertError> {
             instancePrecondition()
             return instance.decode(encodedData: encodedData)
         }
 
-
         public static func check(cose: DGCHolder, forceUpdate: Bool, _ completionHandler: @escaping (CheckResults) -> Void) {
             instancePrecondition()
             return instance.check(cose: cose, forceUpdate: forceUpdate, completionHandler)
         }
-
     }
 
     public static func restartTrustListUpdate(completionHandler: @escaping () -> Void, updateTimeInterval: TimeInterval) {

--- a/Sources/CovidCertificateSDK/Models/CheckResults.swift
+++ b/Sources/CovidCertificateSDK/Models/CheckResults.swift
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Foundation
+
+public struct CheckResults {
+    let signature: Result<ValidationResult, ValidationError>
+    let revocationStatus: Result<ValidationResult, ValidationError>
+    let nationalRules: Result<VerificationResult, NationalRulesError>
+}

--- a/Sources/CovidCertificateSDK/Models/CheckResults.swift
+++ b/Sources/CovidCertificateSDK/Models/CheckResults.swift
@@ -11,7 +11,7 @@
 import Foundation
 
 public struct CheckResults {
-    let signature: Result<ValidationResult, ValidationError>
-    let revocationStatus: Result<ValidationResult, ValidationError>
-    let nationalRules: Result<VerificationResult, NationalRulesError>
+    public let signature: Result<ValidationResult, ValidationError>
+    public let revocationStatus: Result<ValidationResult, ValidationError>
+    public let nationalRules: Result<VerificationResult, NationalRulesError>
 }

--- a/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
+++ b/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Foundation
+
+public struct DGCVerifierHolder {
+
+    internal let dgc: DGCHolder
+
+    init(dgc: DGCHolder) {
+        self.dgc = dgc
+    }
+
+    // Only expose properties needed for verification apps
+
+    public var person: Person {
+        dgc.healthCert.person
+    }
+
+}

--- a/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
+++ b/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
@@ -12,7 +12,7 @@ import Foundation
 
 public struct DGCVerifierHolder {
 
-    internal let dgc: DGCHolder
+    let dgc: DGCHolder
 
     init(dgc: DGCHolder) {
         self.dgc = dgc

--- a/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
+++ b/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
@@ -11,7 +11,6 @@
 import Foundation
 
 public struct DGCVerifierHolder {
-
     let dgc: DGCHolder
 
     init(dgc: DGCHolder) {
@@ -23,5 +22,4 @@ public struct DGCVerifierHolder {
     public var person: Person {
         dgc.healthCert.person
     }
-
 }

--- a/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
+++ b/Sources/CovidCertificateSDK/Models/DGCVerifierHolder.swift
@@ -22,4 +22,8 @@ public struct DGCVerifierHolder {
     public var person: Person {
         dgc.healthCert.person
     }
+
+    public var dateOfBirth: String {
+        dgc.healthCert.dateOfBirth
+    }
 }

--- a/Sources/CovidCertificateSDK/NationalRules/AcceptedProducts/AcceptedProducts.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/AcceptedProducts/AcceptedProducts.swift
@@ -12,25 +12,25 @@
 import Foundation
 
 class AcceptedProducts {
-    public static var shared = AcceptedProducts()
+    static var shared = AcceptedProducts()
 
     private let acceptedTests: AcceptedTests
     private let acceptedVaccines: AcceptedVaccines
 
     // MARK: - Vaccination API
 
-    public func vaccineIsAccepted(vaccination: Vaccination) -> Bool {
+    func vaccineIsAccepted(vaccination: Vaccination) -> Bool {
         return acceptedVaccines.entries.contains { $0.code == vaccination.medicinialProduct }
     }
 
-    public func totalNumberOfDoses(vaccination: Vaccination) -> UInt64? {
+    func totalNumberOfDoses(vaccination: Vaccination) -> UInt64? {
         let entry = acceptedVaccines.entries.first { $0.code == vaccination.medicinialProduct }
         return entry?.totalDosisNumber
     }
 
     // MARK: - Test API
 
-    public func testIsAccepted(test: Test) -> Bool {
+    func testIsAccepted(test: Test) -> Bool {
         if test.type == TestType.Pcr.rawValue {
             return true
         }

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesVerifier.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesVerifier.swift
@@ -64,7 +64,7 @@ class NationalRulesVerifier {
 
     // MARK: - Test
 
-    public func verifyTest(test: Test, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
+    func verifyTest(test: Test, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
         // tg must be sars-cov2
         if !test.isTargetDiseaseCorrect {
             completionHandler(.failure(.WRONG_DISEASE_TARGET))
@@ -109,7 +109,7 @@ class NationalRulesVerifier {
 
     // MARK: - Vaccine
 
-    public func verifyVaccine(vaccine: Vaccination, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
+    func verifyVaccine(vaccine: Vaccination, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
         // tg must be sars-cov2
         if !vaccine.isTargetDiseaseCorrect {
             completionHandler(.failure(.WRONG_DISEASE_TARGET))
@@ -151,7 +151,7 @@ class NationalRulesVerifier {
 
     // MARK: - Recoveery
 
-    public func verifyRecovery(recovery: PastInfection, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
+    func verifyRecovery(recovery: PastInfection, _ completionHandler: @escaping (Result<VerificationResult, NationalRulesError>) -> Void) {
         if recovery.disease != Disease.SarsCov2.rawValue {
             completionHandler(.failure(.WRONG_DISEASE_TARGET))
             return

--- a/Sources/CovidCertificateSDK/ProductNameManager.swift
+++ b/Sources/CovidCertificateSDK/ProductNameManager.swift
@@ -23,31 +23,31 @@ class ProductNameManager {
 
     // MARK: - Shared instance
 
-    public static let shared = ProductNameManager()
+    static let shared = ProductNameManager()
 
     // MARK: - API
 
-    public func vaccineManufacturer(key: String?) -> String? {
+    func vaccineManufacturer(key: String?) -> String? {
         return vaccineManufacturers.productName(key: key)
     }
 
-    public func vaccineProductName(key: String?) -> String? {
+    func vaccineProductName(key: String?) -> String? {
         return vaccineProducts.productName(key: key)
     }
 
-    public func vaccineProphylaxisName(key: String?) -> String? {
+    func vaccineProphylaxisName(key: String?) -> String? {
         return vaccineProphylaxis.productName(key: key)
     }
 
-    public func testManufacturerName(key: String?) -> String? {
+    func testManufacturerName(key: String?) -> String? {
         return testManufacturers.productName(key: key)
     }
 
-    public func testTypeName(key: String?) -> String? {
+    func testTypeName(key: String?) -> String? {
         return testTypes.productName(key: key)
     }
 
-    public func testResultName(key: String?) -> String? {
+    func testResultName(key: String?) -> String? {
         return testResults.productName(key: key)
     }
 
@@ -67,17 +67,17 @@ class ProductNameManager {
 }
 
 class ProductEntry: Codable {
-    public let display: String?
-    public let lang: String?
-    public let active: Bool?
-    public let system: String?
-    public let version: String?
+    let display: String?
+    let lang: String?
+    let active: Bool?
+    let system: String?
+    let version: String?
 }
 
 class Products: Codable {
-    public let valueSetId: String?
-    public let valueSetDate: String?
-    public let valueSetValues: [String: ProductEntry]
+    let valueSetId: String?
+    let valueSetDate: String?
+    let valueSetValues: [String: ProductEntry]
 
     init() {
         valueSetId = nil
@@ -87,7 +87,7 @@ class Products: Codable {
 
     // MARK: - Product name helper
 
-    public func productName(key: String?) -> String? {
+    func productName(key: String?) -> String? {
         guard let k = key,
               let p = valueSetValues[k],
               let name = p.display

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
@@ -12,9 +12,9 @@
 import Foundation
 import JSON
 
-public class NationalRulesList: Codable, JWTExtension {
-    public var validDuration: Int64 = 0
-    public var requestData: Data? {
+class NationalRulesList: Codable, JWTExtension {
+    var validDuration: Int64 = 0
+    var requestData: Data? {
         didSet {
             if let newValue = requestData {
                 rules = JSON(newValue)["rules"]
@@ -35,9 +35,9 @@ public class NationalRulesList: Codable, JWTExtension {
     }
 
     // Allow default constructor
-    public init() {}
+    init() {}
 
-    public required init(from decoder: Decoder) throws {
+    required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         validDuration = try container.decode(Int64.self, forKey: .validDuration)
         requestData = try? container.decode(Data.self, forKey: .requestData)
@@ -48,7 +48,7 @@ public class NationalRulesList: Codable, JWTExtension {
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(validDuration, forKey: .validDuration)
         try container.encode(requestData, forKey: .requestData)

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
@@ -19,7 +19,7 @@ class NationalRulesListUpdate: TrustListUpdate {
 
     // MARK: - Update
 
-    override internal func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
+    override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         let request = CovidCertificateSDK.currentEnvironment.nationalRulesListService.request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (data, _, error) = session.synchronousDataTask(with: request)
 
@@ -57,12 +57,12 @@ class NationalRulesListUpdate: TrustListUpdate {
         return nil
     }
 
-    override internal func isListStillValid() -> Bool {
+    override func isListStillValid() -> Bool {
         return trustStorage.nationalRulesListIsStillValid()
     }
 }
 
-public extension Data {
+extension Data {
     static func data(base64urlEncoded: String) -> Data? {
         let paddingLength = 4 - base64urlEncoded.count % 4
         let padding = (paddingLength < 4) ? String(repeating: "=", count: paddingLength) : ""

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -18,7 +18,7 @@ class RevocationListUpdate: TrustListUpdate {
 
     // MARK: - Update
 
-    override internal func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
+    override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         // download data and update local storage
         let request = CovidCertificateSDK.currentEnvironment.revocationListService.request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (data, _, error) = session.synchronousDataTask(with: request)
@@ -49,7 +49,7 @@ class RevocationListUpdate: TrustListUpdate {
         return nil
     }
 
-    override internal func isListStillValid() -> Bool {
+    override func isListStillValid() -> Bool {
         return trustStorage.revocationListIsValid()
     }
 }

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificates.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificates.swift
@@ -11,21 +11,21 @@
 
 import Foundation
 
-public class TrustCertificates: Codable, JWTExtension {
-    public var certs: [TrustCertificate] = []
+class TrustCertificates: Codable, JWTExtension {
+    var certs: [TrustCertificate] = []
 }
 
-public class TrustCertificate: Codable {
-    public var keyId: String
-    public var use: String
-    public var alg: String
-    public var subjectPublicKeyInfo: String?
-    public var crv: String?
-    public var x: String?
-    public var y: String?
+class TrustCertificate: Codable {
+    var keyId: String
+    var use: String
+    var alg: String
+    var subjectPublicKeyInfo: String?
+    var crv: String?
+    var x: String?
+    var y: String?
 }
 
-public class ActiveTrustCertificates: Codable, JWTExtension {
-    public var activeKeyIds: [String] = []
-    public var validDuration: Int64
+class ActiveTrustCertificates: Codable, JWTExtension {
+    var activeKeyIds: [String] = []
+    var validDuration: Int64
 }

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -22,7 +22,7 @@ class TrustCertificatesUpdate: TrustListUpdate {
 
     // MARK: - Update
 
-    override internal func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
+    override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         // update active certificates service
         let requestActive = CovidCertificateSDK.currentEnvironment.activeCertificatesService.request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (dataActive, _, errorActive) = session.synchronousDataTask(with: requestActive)
@@ -109,7 +109,7 @@ class TrustCertificatesUpdate: TrustListUpdate {
         return nil
     }
 
-    override internal func isListStillValid() -> Bool {
+    override func isListStillValid() -> Bool {
         return trustStorage.certificateListIsValid()
     }
 }

--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-public protocol TrustlistManagerProtocol {
+protocol TrustlistManagerProtocol {
     static var jwsVerifier: JWSVerifier { get }
     var revocationListUpdater: TrustListUpdate { get }
     var trustCertificateUpdater: TrustListUpdate { get }
@@ -25,7 +25,7 @@ public protocol TrustlistManagerProtocol {
 class TrustlistManager: TrustlistManagerProtocol {
     // MARK: - JWS verification
 
-    public static var jwsVerifier: JWSVerifier {
+    static var jwsVerifier: JWSVerifier {
         guard let data = Bundle.module.url(forResource: "swiss_governmentrootcaii", withExtension: "der") else {
             fatalError("Signing CA not in Bundle")
         }
@@ -92,7 +92,7 @@ class TrustlistManager: TrustlistManagerProtocol {
     }
 }
 
-public class TrustListUpdate {
+class TrustListUpdate {
     // MARK: - Operation queue handling
 
     private let operationQueue = OperationQueue()
@@ -103,7 +103,7 @@ public class TrustListUpdate {
 
     private var lastError: NetworkError?
 
-    internal let trustStorage: TrustStorageProtocol
+    let trustStorage: TrustStorageProtocol
 
     // MARK: - Add Check Operation
 
@@ -114,7 +114,7 @@ public class TrustListUpdate {
         forceUpdateQueue.maxConcurrentOperationCount = 1
     }
 
-    public func forceUpdate(completion: @escaping (() -> Void)) {
+    func forceUpdate(completion: @escaping (() -> Void)) {
         let updateAlreadyRunnning = forceUpdateOperation != nil
 
         if !updateAlreadyRunnning {
@@ -132,7 +132,7 @@ public class TrustListUpdate {
         }
     }
 
-    public func addCheckOperation(forceUpdate: Bool, checkOperation: @escaping ((NetworkError?) -> Void)) {
+    func addCheckOperation(forceUpdate: Bool, checkOperation: @escaping ((NetworkError?) -> Void)) {
         DispatchQueue.global().async {
             let updateNeeeded = !self.isListStillValid() || forceUpdate
             let updateAlreadyRunnning = self.updateOperation != nil
@@ -155,12 +155,12 @@ public class TrustListUpdate {
 
     // MARK: - Update
 
-    internal func synchronousUpdate(ignoreLocalCache _: Bool = false) -> NetworkError? {
+    func synchronousUpdate(ignoreLocalCache _: Bool = false) -> NetworkError? {
         // download data and update local storage
         return nil
     }
 
-    internal func isListStillValid() -> Bool {
+    func isListStillValid() -> Bool {
         return true
     }
 

--- a/Sources/CovidCertificateSDK/TrustList/TrustListPublicKey.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListPublicKey.swift
@@ -12,11 +12,11 @@
 import Foundation
 import Security
 
-public class TrustListPublicKey {
+class TrustListPublicKey {
     // MARK: - Elements
 
-    public let keyId: String
-    public let key: SecKey
+    let keyId: String
+    let key: SecKey
 
     // MARK: - Used with RSA
 

--- a/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
@@ -11,7 +11,7 @@
 
 import Foundation
 
-public protocol TrustStorageProtocol {
+protocol TrustStorageProtocol {
     func revokedCertificates() -> [String]
     func updateRevocationList(_ list: RevocationList) -> Bool
     func revocationListIsValid() -> Bool
@@ -45,13 +45,13 @@ class TrustStorage: TrustStorageProtocol {
 
     // MARK: - Revocation List
 
-    public func revokedCertificates() -> [String] {
+    func revokedCertificates() -> [String] {
         return revocationQueue.sync {
             return self.revocationStorage.revocationList.revokedCerts
         }
     }
 
-    public func updateRevocationList(_ list: RevocationList) -> Bool {
+    func updateRevocationList(_ list: RevocationList) -> Bool {
         revocationQueue.sync {
             self.revocationStorage.revocationList = list
             self.revocationStorage.lastRevocationListDownload = Int64(Date().timeIntervalSince1970 * 1000.0)
@@ -148,18 +148,18 @@ class TrustStorage: TrustStorageProtocol {
 }
 
 class RevocationStorage: Codable {
-    public var revocationList = RevocationList()
-    public var lastRevocationListDownload: Int64 = 0
+    var revocationList = RevocationList()
+    var lastRevocationListDownload: Int64 = 0
 }
 
 class ActiveCertificatesStorage: Codable {
-    public var activeCertificates: [TrustCertificate] = []
-    public var certificateSince: String = ""
-    public var certificateValidDuration: Int64 = 0
-    public var lastCertificateListDownload: Int64 = 0
+    var activeCertificates: [TrustCertificate] = []
+    var certificateSince: String = ""
+    var certificateValidDuration: Int64 = 0
+    var lastCertificateListDownload: Int64 = 0
 }
 
 class NationalRulesStorage: Codable {
-    public var nationalRulesList = NationalRulesList()
-    public var lastNationalRulesListDownload: Int64 = 0
+    var nationalRulesList = NationalRulesList()
+    var lastNationalRulesListDownload: Int64 = 0
 }

--- a/Sources/CovidCertificateSDK/ehn/Asn1Encoder.swift
+++ b/Sources/CovidCertificateSDK/ehn/Asn1Encoder.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-public class Asn1Encoder {
+class Asn1Encoder {
     // 32 for ES256
-    public func convertRawSignatureIntoAsn1(_ data: Data, _ digestLengthInBytes: Int = 32) -> Data {
+    func convertRawSignatureIntoAsn1(_ data: Data, _ digestLengthInBytes: Int = 32) -> Data {
         guard data.count >= digestLengthInBytes else {
             return Data()
         }

--- a/Sources/CovidCertificateSDK/ehn/CBORExtensions.swift
+++ b/Sources/CovidCertificateSDK/ehn/CBORExtensions.swift
@@ -86,7 +86,7 @@ extension CBOR {
     }
 }
 
-public extension CBOR.Tag {
+extension CBOR.Tag {
     static let coseSign1Item = CBOR.Tag(rawValue: 18)
     static let coseSignItem = CBOR.Tag(rawValue: 98)
 }

--- a/Sources/CovidCertificateSDK/ehn/CWT.swift
+++ b/Sources/CovidCertificateSDK/ehn/CWT.swift
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftCBOR
 
-public struct CWT {
+struct CWT {
     let iss: String?
     let exp: CBOR?
     let iat: CBOR?

--- a/Sources/CovidCertificateSDK/ehn/Extensions.swift
+++ b/Sources/CovidCertificateSDK/ehn/Extensions.swift
@@ -14,7 +14,7 @@ extension Data {
         return map { String(format: "%02x ", $0) }.joined()
     }
 
-    public var bytes: [UInt8] {
+    var bytes: [UInt8] {
         return [UInt8](self)
     }
 

--- a/Sources/CovidCertificateSDK/ehn/SecureStorage/Enclave.swift
+++ b/Sources/CovidCertificateSDK/ehn/SecureStorage/Enclave.swift
@@ -27,7 +27,7 @@
 
 import Foundation
 
-public enum Enclave {
+enum Enclave {
     static let encryptAlg = SecKeyAlgorithm.eciesEncryptionCofactorVariableIVX963SHA256AESGCM
     static let signAlg = SecKeyAlgorithm.ecdsaSignatureMessageX962SHA512
 
@@ -159,7 +159,7 @@ public enum Enclave {
         return (isValid, err)
     }
 
-    public static func sign(
+    static func sign(
         data: Data,
         with key: SecKey,
         using algorithm: SecKeyAlgorithm? = nil,

--- a/Sources/CovidCertificateSDK/ehn/SecureStorage/SecureStorage.swift
+++ b/Sources/CovidCertificateSDK/ehn/SecureStorage/SecureStorage.swift
@@ -32,7 +32,7 @@ struct SecureDB: Codable {
     let signature: Data
 }
 
-public struct SecureStorage<T: Codable> {
+struct SecureStorage<T: Codable> {
     let documents: URL! = try? FileManager.default.url(
         for: .documentDirectory,
         in: .userDomainMask,
@@ -44,7 +44,7 @@ public struct SecureStorage<T: Codable> {
 
     let name: String
 
-    public init(name: String) {
+    init(name: String) {
         self.name = name
         secureStorageKey = Enclave.loadOrGenerateKey(with: "\(name)_secureStorageKey")
     }
@@ -52,7 +52,7 @@ public struct SecureStorage<T: Codable> {
     /**
      Loads encrypted db and overrides it with an empty one if that fails.
      */
-    public func loadOverride(fallback: T, completion: ((T?) -> Void)? = nil) {
+    func loadOverride(fallback: T, completion: ((T?) -> Void)? = nil) {
         load { result in
             if result != nil {
                 completion?(result)
@@ -64,7 +64,7 @@ public struct SecureStorage<T: Codable> {
         }
     }
 
-    public func load(completion: ((T?) -> Void)? = nil) {
+    func load(completion: ((T?) -> Void)? = nil) {
         if !FileManager.default.fileExists(atPath: path.path) {
             completion?(nil)
             return
@@ -91,7 +91,7 @@ public struct SecureStorage<T: Codable> {
         }
     }
 
-    public func loadSynchronously() -> T? {
+    func loadSynchronously() -> T? {
         if !FileManager.default.fileExists(atPath: path.path) {
             return nil
         }
@@ -120,7 +120,7 @@ public struct SecureStorage<T: Codable> {
         return t
     }
 
-    public func saveSynchronously(_ instance: T) -> Bool {
+    func saveSynchronously(_ instance: T) -> Bool {
         let semaphore = DispatchSemaphore(value: 0)
         var outcome = false
         save(instance) { result in
@@ -132,7 +132,7 @@ public struct SecureStorage<T: Codable> {
         return outcome
     }
 
-    public func save(_ instance: T, completion: ((Bool) -> Void)? = nil) {
+    func save(_ instance: T, completion: ((Bool) -> Void)? = nil) {
         guard
             let data = try? JSONEncoder().encode(instance),
             let key = secureStorageKey,

--- a/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
+++ b/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
@@ -15,7 +15,7 @@ import Foundation
 class TestTrustlistManager: TrustlistManagerProtocol {
     // MARK: - JWS verification
 
-    public static var jwsVerifier: JWSVerifier {
+    static var jwsVerifier: JWSVerifier {
         guard let data = Bundle.module.url(forResource: "swiss_governmentrootcaii", withExtension: "der") else {
             fatalError("Signing CA not in Bundle")
         }
@@ -62,7 +62,7 @@ class TestTrustlistManager: TrustlistManagerProtocol {
 class TestTrustListUpdate: TrustListUpdate {
     // MARK: - Update
 
-    override internal func synchronousUpdate(ignoreLocalCache _: Bool = false) -> NetworkError? {
+    override func synchronousUpdate(ignoreLocalCache _: Bool = false) -> NetworkError? {
         // update active certificates service
         sleep(1)
         return nil


### PR DESCRIPTION
- removes all unneeded access control modifiert
- split decode and check methods into `Verifier` and `Check` namespace. This allows the SDK to decide which information to expose to the app
- merge all 3 check methods into one