### PR TITLE
Check signature before checking expiration

### DIFF
--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -110,17 +110,6 @@ struct CovidCertificateImpl {
     }
 
     func checkSignature(holder: CertificateHolder, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
-        switch holder.cwt.isValid() {
-        case let .success(isValid):
-            if !isValid {
-                completionHandler(.failure(.CWT_EXPIRED))
-                return
-            }
-        case let .failure(error):
-            completionHandler(.failure(error))
-            return
-        }
-
         switch holder.certificate {
         case let certificate as DCCCert:
             if certificate.immunisationType == nil {
@@ -138,7 +127,24 @@ struct CovidCertificateImpl {
                 let list = self.trustListManager.trustStorage.activeCertificatePublicKeys(useFilters: holder.certificate.type.trustListUseFilters)
                 let validationError = list.hasValidSignature(for: holder)
 
-                completionHandler(.success(ValidationResult(isValid: validationError == nil, payload: holder.certificate, error: validationError)))
+                // if there is a signature error we return it before checking the cwt validity
+                if let error = validationError {
+                    completionHandler(.success(ValidationResult(isValid: false, payload: holder.certificate, error: error)))
+                    return
+                }
+
+                switch holder.cwt.isValid() {
+                case let .success(isValid):
+                    if !isValid {
+                        completionHandler(.failure(.CWT_EXPIRED))
+                        return
+                    }
+                case let .failure(error):
+                    completionHandler(.failure(error))
+                    return
+                }
+
+                completionHandler(.success(ValidationResult(isValid: true, payload: holder.certificate, error: nil)))
             }
         })
     }


### PR DESCRIPTION
Check the signature even if the CWT is expired. This is important to the app can tell if an expired signature was valid.