### PR TITLE
Bugfix: fixes race condition crash

### DIFF
--- a/Tests/CovidCertificateSDKTests/TrustListUpdateTests.swift
+++ b/Tests/CovidCertificateSDKTests/TrustListUpdateTests.swift
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+@testable import CovidCertificateSDK
+import XCTest
+
+final class TrustListUpdateTest: XCTestCase {
+    func testConcurrentChecks() {
+        let update = TestTrustListUpdate(trustStorage: TestTrustStorage(publicKeys: []))
+        let operationQueue = OperationQueue()
+        operationQueue.maxConcurrentOperationCount = .max
+
+        for _ in 0...10000 {
+            operationQueue.addOperation {
+                update.addCheckOperation(forceUpdate: true, checkOperation: { _ in })
+                Thread.sleep(forTimeInterval: 0.1)
+                update.addCheckOperation(forceUpdate: false, checkOperation: { _ in })
+            }
+        }
+    }
+}

--- a/Tests/CovidCertificateSDKTests/TrustListUpdateTests.swift
+++ b/Tests/CovidCertificateSDKTests/TrustListUpdateTests.swift
@@ -17,7 +17,7 @@ final class TrustListUpdateTest: XCTestCase {
         let operationQueue = OperationQueue()
         operationQueue.maxConcurrentOperationCount = .max
 
-        for _ in 0...10000 {
+        for _ in 0 ... 10000 {
             operationQueue.addOperation {
                 update.addCheckOperation(forceUpdate: true, checkOperation: { _ in })
                 Thread.sleep(forTimeInterval: 0.1)


### PR DESCRIPTION
- Adds an serial DispatchQueue to `TrustListUpdate`. 
- This solves raceconditions for accessing `updateOperation` and `forceUpdateOperation`.

This is the [relevant part](https://github.com/admin-ch/CovidCertificate-SDK-iOS/blob/b44fe743613f09a56f677f0c1275152e75a00063/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift#L141-L147) of the code. The property `updateOperation` is first set and then force-unwrapped. If another Thread sets the variable to nil in the meantime or adds the operation to the queue a crash happens.