### PR TITLE
Feature: TrustCertificates request synchronisation

### DIFF
--- a/Sources/CovidCertificateSDK/Networking/Backend.swift
+++ b/Sources/CovidCertificateSDK/Networking/Backend.swift
@@ -20,15 +20,17 @@ struct Backend {
         self.version = version
     }
 
-    var versionedURL: URL {
-        baseURL.appendingPathComponent(version ?? "")
+    func getVersionedURL(overwriteVersion: String? = nil) -> URL {
+        baseURL.appendingPathComponent(overwriteVersion ?? version ?? "")
     }
 
     func endpoint(_ path: String, method: Endpoint.Method = .get,
                   queryParameters: [String: String]? = nil,
-                  headers: [String: String]? = nil, body: Encodable? = nil) -> Endpoint
+                  headers: [String: String]? = nil,
+                  body: Encodable? = nil,
+                  overwriteVersion: String? = nil) -> Endpoint
     {
-        var components = URLComponents(url: versionedURL.appendingPathComponent(path), resolvingAgainstBaseURL: true)!
+        var components = URLComponents(url: getVersionedURL(overwriteVersion: overwriteVersion).appendingPathComponent(path), resolvingAgainstBaseURL: true)!
         if let queryParameters = queryParameters {
             let sortedKeys = Array(queryParameters.keys).sorted()
             components.queryItems = sortedKeys.map { URLQueryItem(name: $0, value: queryParameters[$0]) }

--- a/Sources/CovidCertificateSDK/Networking/Environment.swift
+++ b/Sources/CovidCertificateSDK/Networking/Environment.swift
@@ -17,13 +17,14 @@ public enum SDKEnvironment {
     case prod
 
     var trustBackend: Backend {
+        let version = "v1"
         switch self {
         case .dev:
-            return Backend("https://www.cc-d.bit.admin.ch/trust", version: "v1")
+            return Backend("https://www.cc-d.bit.admin.ch/trust", version: version)
         case .abn:
-            return Backend("https://www.cc-a.bit.admin.ch/trust", version: "v1")
+            return Backend("https://www.cc-a.bit.admin.ch/trust", version: version)
         case .prod:
-            return Backend("https://www.cc.bit.admin.ch/trust", version: "v1")
+            return Backend("https://www.cc.bit.admin.ch/trust", version: version)
         }
     }
 
@@ -37,12 +38,17 @@ public enum SDKEnvironment {
         return trustBackend.endpoint("verificationRules", headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
     }
 
-    func trustCertificatesService(since: String) -> Endpoint {
-        return trustBackend.endpoint("keys/updates", queryParameters: ["certFormat": "IOS", "since": since], headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
+    func trustCertificatesService(since: String, upTo: String) -> Endpoint {
+        return trustBackend.endpoint("keys/updates",
+                                     queryParameters: ["certFormat": "IOS",
+                                                       "since": since,
+                                                       "upTo": upTo],
+                                     headers: ["Accept": SDKEnvironment.applicationJwtPlusJws],
+                                     overwriteVersion: "v2")
     }
 
     var activeCertificatesService: Endpoint {
-        return trustBackend.endpoint("keys/list", headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
+        return trustBackend.endpoint("keys/list", headers: ["Accept": SDKEnvironment.applicationJwtPlusJws], overwriteVersion: "v2")
     }
 
     func metadata() -> Endpoint {

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -31,6 +31,8 @@ class TrustCertificatesUpdate: TrustListUpdate {
             return errorActive?.asNetworkError()
         }
 
+        // obtain up-to field from activeCertificatesService
+        // this is needed to sychronize the both request done in this method
         guard let d = dataActive,
               let httpResponse = response as? HTTPURLResponse,
               let upTo = httpResponse.value(forHeaderField: "up-to") else {


### PR DESCRIPTION
This PR implements the synchronisation of the `/trust/v1/keys/list` and `/trust/v1/keys/updates` request. 
The `/trust/v1/keys/list` request contains the header field up-to which later is passed to the `/trust/v1/keys/updates` as a query parameter.
Corresponding backend PR: https://github.com/admin-ch/CovidCertificate-App-Verifier-Service/pull/33