### PR TITLE
Feature: Revocation diff loading

### DIFF
--- a/Sources/CovidCertificateSDK/Networking/Backend.swift
+++ b/Sources/CovidCertificateSDK/Networking/Backend.swift
@@ -20,15 +20,17 @@ struct Backend {
         self.version = version
     }
 
-    var versionedURL: URL {
-        baseURL.appendingPathComponent(version ?? "")
+    func getVersionedURL(overwriteVersion: String? = nil) -> URL {
+           baseURL.appendingPathComponent(overwriteVersion ?? version ?? "")
     }
 
     func endpoint(_ path: String, method: Endpoint.Method = .get,
                   queryParameters: [String: String]? = nil,
-                  headers: [String: String]? = nil, body: Encodable? = nil) -> Endpoint
+                  headers: [String: String]? = nil,
+                  body: Encodable? = nil,
+                  overwriteVersion: String? = nil) -> Endpoint
     {
-        var components = URLComponents(url: versionedURL.appendingPathComponent(path), resolvingAgainstBaseURL: true)!
+        var components = URLComponents(url: getVersionedURL(overwriteVersion: overwriteVersion).appendingPathComponent(path), resolvingAgainstBaseURL: true)!
         if let queryParameters = queryParameters {
             let sortedKeys = Array(queryParameters.keys).sorted()
             components.queryItems = sortedKeys.map { URLQueryItem(name: $0, value: queryParameters[$0]) }

--- a/Sources/CovidCertificateSDK/Networking/Backend.swift
+++ b/Sources/CovidCertificateSDK/Networking/Backend.swift
@@ -21,7 +21,7 @@ struct Backend {
     }
 
     func getVersionedURL(overwriteVersion: String? = nil) -> URL {
-           baseURL.appendingPathComponent(overwriteVersion ?? version ?? "")
+        baseURL.appendingPathComponent(overwriteVersion ?? version ?? "")
     }
 
     func endpoint(_ path: String, method: Endpoint.Method = .get,

--- a/Sources/CovidCertificateSDK/Networking/Environment.swift
+++ b/Sources/CovidCertificateSDK/Networking/Environment.swift
@@ -29,11 +29,11 @@ public enum SDKEnvironment {
 
     public static let applicationJwtPlusJws: String = "application/json+jws"
 
-    func revocationListService(since: String?) -> Endpoint {
+    func revocationListService(upToDate: String?) -> Endpoint {
         var queryParameters: [String: String]?
 
-        if let since = since {
-            queryParameters = ["since": since]
+        if let upToDate = upToDate {
+            queryParameters = ["up-to-date": upToDate]
         }
 
         return trustBackend.endpoint("revocationList",

--- a/Sources/CovidCertificateSDK/Networking/Environment.swift
+++ b/Sources/CovidCertificateSDK/Networking/Environment.swift
@@ -29,8 +29,16 @@ public enum SDKEnvironment {
 
     public static let applicationJwtPlusJws: String = "application/json+jws"
 
-    var revocationListService: Endpoint {
-        return trustBackend.endpoint("revocationList", headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
+    func revocationListService(since: String?) -> Endpoint {
+        var queryParameters: [String: String]? = nil
+
+        if let since = since {
+            queryParameters = ["since": since]
+        }
+
+        return trustBackend.endpoint("revocationList",
+                                     queryParameters: queryParameters,
+                                     headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
     }
 
     var nationalRulesListService: Endpoint {

--- a/Sources/CovidCertificateSDK/Networking/Environment.swift
+++ b/Sources/CovidCertificateSDK/Networking/Environment.swift
@@ -30,7 +30,7 @@ public enum SDKEnvironment {
     public static let applicationJwtPlusJws: String = "application/json+jws"
 
     func revocationListService(since: String?) -> Endpoint {
-        var queryParameters: [String: String]? = nil
+        var queryParameters: [String: String]?
 
         if let since = since {
             queryParameters = ["since": since]

--- a/Sources/CovidCertificateSDK/Networking/Environment.swift
+++ b/Sources/CovidCertificateSDK/Networking/Environment.swift
@@ -29,16 +29,17 @@ public enum SDKEnvironment {
 
     public static let applicationJwtPlusJws: String = "application/json+jws"
 
-    func revocationListService(upToDate: String?) -> Endpoint {
+    func revocationListService(since: String?) -> Endpoint {
         var queryParameters: [String: String]?
 
-        if let upToDate = upToDate {
-            queryParameters = ["up-to-date": upToDate]
+        if let since = since {
+            queryParameters = ["since": since]
         }
 
         return trustBackend.endpoint("revocationList",
                                      queryParameters: queryParameters,
-                                     headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
+                                     headers: ["Accept": SDKEnvironment.applicationJwtPlusJws],
+                                     overwriteVersion: "v2")
     }
 
     var nationalRulesListService: Endpoint {

--- a/Sources/CovidCertificateSDK/TrustList/RevocationList.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationList.swift
@@ -12,6 +12,6 @@
 import Foundation
 
 public class RevocationList: Codable, JWTExtension {
-    public var revokedCerts: [String] = []
+    public var revokedCerts: Set<String> = []
     public var validDuration: Int64 = 0
 }

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -23,7 +23,7 @@ class RevocationListUpdate: TrustListUpdate {
 
     override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         // download data and update local storage
-        let request = CovidCertificateSDK.currentEnvironment.revocationListService(since: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
+        let request = CovidCertificateSDK.currentEnvironment.revocationListService(upToDate: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (data, response, error) = session.synchronousDataTask(with: request)
 
         if error != nil {

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -23,7 +23,7 @@ class RevocationListUpdate: TrustListUpdate {
 
     override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         // download data and update local storage
-        let request = CovidCertificateSDK.currentEnvironment.revocationListService(upToDate: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
+        let request = CovidCertificateSDK.currentEnvironment.revocationListService(since: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (data, response, error) = session.synchronousDataTask(with: request)
 
         if error != nil {

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -19,39 +19,65 @@ class RevocationListUpdate: TrustListUpdate {
     @UBUserDefault(key: "covidcertififcate.revocations.nextSince", defaultValue: nil)
     var nextSince: String?
 
+    private static let falseConstant = "false"
+
+    private static let trueConstant = "true"
+
+    private static let maximumNumberOfRequests = 20
+
     // MARK: - Update
 
     override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
-        // download data and update local storage
-        let request = CovidCertificateSDK.currentEnvironment.revocationListService(since: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
-        let (data, response, error) = session.synchronousDataTask(with: request)
+        var listNeedsUpdate = true
+        var requestsCount = 0
 
-        if error != nil {
-            return error?.asNetworkError()
+        while listNeedsUpdate, requestsCount < Self.maximumNumberOfRequests {
+            requestsCount = requestsCount + 1
+
+            // download data and update local storage
+            let request = CovidCertificateSDK.currentEnvironment.revocationListService(since: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
+            let (data, response, error) = session.synchronousDataTask(with: request)
+
+            if error != nil {
+                return error?.asNetworkError()
+            }
+
+            guard let d = data,
+                  let httpResponse = response as? HTTPURLResponse else {
+                return .NETWORK_PARSE_ERROR
+            }
+
+            // get the `x-next-since` from HTTP headers, save it and pass to the next request
+            guard let nextSinceHeader = httpResponse.value(forHeaderField: "x-next-since") else {
+                return .NETWORK_PARSE_ERROR
+            }
+
+            nextSince = nextSinceHeader
+
+            // get the `up-to-date` from HTTP headers to decide whether we are at the end
+            guard let upToDate = httpResponse.value(forHeaderField: "up-to-date") else {
+                return .NETWORK_PARSE_ERROR
+            }
+
+            let semaphore = DispatchSemaphore(value: 0)
+            var outcome: Result<RevocationList, JWSError> = .failure(.SIGNATURE_INVALID)
+
+            TrustlistManager.jwsVerifier.verifyAndDecode(httpBody: d) { (result: Result<RevocationList, JWSError>) in
+                outcome = result
+                semaphore.signal()
+            }
+
+            semaphore.wait()
+
+            guard let result = try? outcome.get() else {
+                return .NETWORK_PARSE_ERROR
+            }
+
+            _ = trustStorage.updateRevocationList(result)
+
+            // start another request, as long as revocations are coming in
+            listNeedsUpdate = upToDate == Self.falseConstant
         }
-
-        guard let d = data,
-              let httpResponse = response as? HTTPURLResponse else {
-            return .NETWORK_PARSE_ERROR
-        }
-
-        nextSince = httpResponse.value(forHeaderField: "x-next-since")
-
-        let semaphore = DispatchSemaphore(value: 0)
-        var outcome: Result<RevocationList, JWSError> = .failure(.SIGNATURE_INVALID)
-
-        TrustlistManager.jwsVerifier.verifyAndDecode(httpBody: d) { (result: Result<RevocationList, JWSError>) in
-            outcome = result
-            semaphore.signal()
-        }
-
-        semaphore.wait()
-
-        guard let result = try? outcome.get() else {
-            return .NETWORK_PARSE_ERROR
-        }
-
-        _ = trustStorage.updateRevocationList(result)
         return nil
     }
 

--- a/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
@@ -53,9 +53,9 @@ class TrustStorage: TrustStorageProtocol {
 
     func updateRevocationList(_ list: RevocationList) -> Bool {
         revocationQueue.sync {
-            list.revokedCerts.forEach{ self.revocationStorage.revocationList.revokedCerts.insert($0) }
+            list.revokedCerts.forEach { self.revocationStorage.revocationList.revokedCerts.insert($0) }
             self.revocationStorage.revocationList.validDuration = list.validDuration
-            
+
             self.revocationStorage.lastRevocationListDownload = Int64(Date().timeIntervalSince1970 * 1000.0)
             return self.revocationSecureStorage.saveSynchronously(self.revocationStorage)
         }

--- a/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
+++ b/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
@@ -78,7 +78,7 @@ class TestTrustStorage: TrustStorageProtocol {
 
     // MARK: - Revocation list
 
-    func revokedCertificates() -> [String] {
+    func revokedCertificates() -> Set<String> {
         return []
     }
 


### PR DESCRIPTION
This PR adds the feature that the revocation list is not loaded as a whole but the header from the previous request is passed as a query parameter to the next request. This allows the backend to just return the new revocations. 