### PR TITLE
Don't block main thread in executing restartTrustListUpdate

### DIFF
--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -76,7 +76,7 @@ class TrustlistManager: TrustlistManagerProtocol {
             strongSelf.forceUpdate(completionHandler: completionHandler)
         })
 
-        timer?.schedule(deadline: .now() + updateTimeInterval, repeating: updateTimeInterval)
+        timer?.schedule(deadline: .now(), repeating: updateTimeInterval)
 
         timer?.resume()
     }

--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -69,7 +69,6 @@ class TrustlistManager: TrustlistManagerProtocol {
     }
 
     func restartTrustListUpdate(completionHandler: @escaping (() -> Void), updateTimeInterval: TimeInterval) {
-
         timer = DispatchSource.makeTimerSource(queue: timerQueue)
 
         timer?.setEventHandler(handler: { [weak self] in


### PR DESCRIPTION
Timer.scheduledTimer executes on the current run loop therefore the main queue will be blocked if the restartTrustListUpdate method is called from the main thread. Now a separate DispatchQueue is used.