### PR TITLE
Fix external github action to specific sha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       run: fastlane tests
 
     - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action/composite@v1
+      uses: EnricoMi/publish-unit-test-result-action/composite@95a3aff882d4abe2838b187c66477be7fbf3ddb8
       if: always()
       with:
         files: build/*.xml


### PR DESCRIPTION
Fix possible supply chain attack due to external github actions not being fixed to specific sha-hash. 