### PR TITLE
Expose certificate type for verifier apps

### DIFF
--- a/Sources/CovidCertificateSDK/Models/VerifierCertificateHolder.swift
+++ b/Sources/CovidCertificateSDK/Models/VerifierCertificateHolder.swift
@@ -26,4 +26,8 @@ public struct VerifierCertificateHolder {
     public var dateOfBirth: String {
         value.certificate.dateOfBirthFormatted
     }
+
+    public var certificateType: CertificateType {
+        value.certificate.type
+    }
 }


### PR DESCRIPTION
This is needed to display whether the certificate is only valid in switzerland.