### PR TITLE
Feature: TrustCertificates request synchronisation

### DIFF
--- a/Sources/CovidCertificateSDK/Networking/Environment.swift
+++ b/Sources/CovidCertificateSDK/Networking/Environment.swift
@@ -46,12 +46,17 @@ public enum SDKEnvironment {
         return trustBackend.endpoint("verificationRules", headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
     }
 
-    func trustCertificatesService(since: String) -> Endpoint {
-        return trustBackend.endpoint("keys/updates", queryParameters: ["certFormat": "IOS", "since": since], headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
+    func trustCertificatesService(since: String, upTo: String) -> Endpoint {
+        return trustBackend.endpoint("keys/updates",
+                                     queryParameters: ["certFormat": "IOS",
+                                                       "since": since,
+                                                       "upTo": upTo],
+                                     headers: ["Accept": SDKEnvironment.applicationJwtPlusJws],
+                                     overwriteVersion: "v2")
     }
 
     var activeCertificatesService: Endpoint {
-        return trustBackend.endpoint("keys/list", headers: ["Accept": SDKEnvironment.applicationJwtPlusJws])
+        return trustBackend.endpoint("keys/list", headers: ["Accept": SDKEnvironment.applicationJwtPlusJws], overwriteVersion: "v2")
     }
 
     func metadata() -> Endpoint {

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -25,13 +25,17 @@ class TrustCertificatesUpdate: TrustListUpdate {
     override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         // update active certificates service
         let requestActive = CovidCertificateSDK.currentEnvironment.activeCertificatesService.request(reloadIgnoringLocalCache: ignoreLocalCache)
-        let (dataActive, _, errorActive) = session.synchronousDataTask(with: requestActive)
+        let (dataActive, response, errorActive) = session.synchronousDataTask(with: requestActive)
 
         if errorActive != nil {
             return errorActive?.asNetworkError()
         }
 
-        guard let d = dataActive else {
+        // obtain up-to field from activeCertificatesService
+        // this is needed to sychronize the both request done in this method
+        guard let d = dataActive,
+              let httpResponse = response as? HTTPURLResponse,
+              let upTo = httpResponse.value(forHeaderField: "up-to") else {
             return .NETWORK_PARSE_ERROR
         }
 
@@ -56,7 +60,9 @@ class TrustCertificatesUpdate: TrustListUpdate {
         while listNeedsUpdate, requestsCount < Self.maximumNumberOfRequests {
             requestsCount = requestsCount + 1
 
-            let request = CovidCertificateSDK.currentEnvironment.trustCertificatesService(since: trustStorage.certificateSince()).request(reloadIgnoringLocalCache: ignoreLocalCache)
+            let request = CovidCertificateSDK.currentEnvironment
+                .trustCertificatesService(since: trustStorage.certificateSince(), upTo: upTo)
+                .request(reloadIgnoringLocalCache: ignoreLocalCache)
             let (data, response, error) = session.synchronousDataTask(with: request)
 
             if error != nil {


### PR DESCRIPTION
This PR implements the synchronisation of the /trust/v1/keys/list and /trust/v1/keys/updates request.
The /trust/v1/keys/list request contains the header field up-to which later is passed to the /trust/v1/keys/updates as a query parameter.
Corresponding backend PR: admin-ch/CovidCertificate-App-Verifier-Service#33
This was previously already approved in #65 and then reverted in #68 