### PR TITLE
Raise cocoapods target to 12

### DIFF
--- a/CovidCertificateSDK.podspec
+++ b/CovidCertificateSDK.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |spec|
   spec.homepage     = "https://github.com/admin-ch/CovidCertificate-SDK-iOS"
   spec.license      = { :type => "MPL", :file => "LICENSE" }
   spec.author       = { "ubique" => "covidcertificatesdk@ubique.ch" }
-  spec.platform     = :ios, "11.0"
+  spec.platform     = :ios, "12.0"
   spec.swift_versions = "5.3"
   spec.source       = { :git => "https://github.com/admin-ch/CovidCertificate-SDK-iOS.git", :tag => "v#{spec.version}" }
   spec.source_files  = "Sources/CovidCertificateSDK", "Sources/CovidCertificateSDK/**/*.{h,m,swift}"

--- a/CovidCertificateSDK.podspec
+++ b/CovidCertificateSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "CovidCertificateSDK"
-  spec.version      = ENV['LIB_VERSION'] || '1.0.1'
+  spec.version      = ENV['LIB_VERSION']&[1..-1] || 'v1.0.1'[1..-1]
   spec.summary      = "Implementation of the Electronic Health Certificates (EHN) specification used to verify the validity of COVID Certificates in Switzerland."
   spec.homepage     = "https://github.com/admin-ch/CovidCertificate-SDK-iOS"
   spec.license      = { :type => "MPL", :file => "LICENSE" }


### PR DESCRIPTION
- We have to leave the deployment target for cocoapods at iOS 12 for now since https://github.com/ehn-dcc-development/base45-swift/blob/1.01/base45-swift.podspec#L22 requires iOS 12. I will lower it back down to 11 once https://github.com/ehn-dcc-development/base45-swift/pull/8 is merged.
- fixes the version parsing in the podspec file