### PR TITLE
Fixes podspec version parsing

### DIFF
--- a/CovidCertificateSDK.podspec
+++ b/CovidCertificateSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "CovidCertificateSDK"
-  spec.version      = ENV['LIB_VERSION']&[1..-1] || 'v1.0.1'[1..-1]
+  spec.version      = if ENV['LIB_VERSION'] then ENV['LIB_VERSION'][1..-1] else 'v1.0.1'[1..-1] end
   spec.summary      = "Implementation of the Electronic Health Certificates (EHN) specification used to verify the validity of COVID Certificates in Switzerland."
   spec.homepage     = "https://github.com/admin-ch/CovidCertificate-SDK-iOS"
   spec.license      = { :type => "MPL", :file => "LICENSE" }


### PR DESCRIPTION
The github tag is `v` prefixed but cocoapods dosnt allow the version to start with `v`