### PR TITLE
Use correct error for too many entries national rule

### DIFF
--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -237,7 +237,7 @@ struct CovidCertificateImpl {
                 case let .failure(.TESTS_FAILED(tests)):
                     switch tests.keys.first {
                     case "GR-CH-0001": completionHandler(.failure(.WRONG_DISEASE_TARGET))
-                    case "VR-CH-0000": completionHandler(.failure(.NETWORK_PARSE_ERROR))
+                    case "VR-CH-0000": completionHandler(.failure(.TOO_MANY_VACCINE_ENTRIES))
                     case "VR-CH-0001": completionHandler(.failure(.NOT_FULLY_PROTECTED))
                     case "VR-CH-0002": completionHandler(.failure(.NO_VALID_PRODUCT))
                     case "VR-CH-0003": completionHandler(.failure(.NO_VALID_DATE))
@@ -259,7 +259,7 @@ struct CovidCertificateImpl {
                                                                       validUntil: validityRange?.until,
                                                                       validFrom: validityRange?.from,
                                                                       dateError: .EXPIRED)))
-                    case "TR-CH-0000": completionHandler(.failure(.NETWORK_PARSE_ERROR))
+                    case "TR-CH-0000": completionHandler(.failure(.TOO_MANY_TEST_ENTRIES))
                     case "TR-CH-0001": completionHandler(.failure(.POSITIVE_RESULT))
                     case "TR-CH-0002": completionHandler(.failure(.WRONG_TEST_TYPE))
                     case "TR-CH-0003": completionHandler(.failure(.NO_VALID_PRODUCT))
@@ -267,7 +267,7 @@ struct CovidCertificateImpl {
                     case "TR-CH-0005": completionHandler(.success(VerificationResult(isValid: false, validUntil: certificate.tests?.first?.getValidUntilDate(pcrTestValidityInHours: Int(pcrValidity), ratTestValidityInHours: Int(ratValidity)), validFrom: certificate.tests?.first?.validFromDate, dateError: .NOT_YET_VALID)))
                     case "TR-CH-0006": completionHandler(.success(VerificationResult(isValid: false, validUntil: certificate.tests?.first?.getValidUntilDate(pcrTestValidityInHours: Int(pcrValidity), ratTestValidityInHours: Int(ratValidity)), validFrom: certificate.tests?.first?.validFromDate, dateError: .EXPIRED)))
                     case "TR-CH-0007": completionHandler(.success(VerificationResult(isValid: false, validUntil: certificate.tests?.first?.getValidUntilDate(pcrTestValidityInHours: Int(pcrValidity), ratTestValidityInHours: Int(ratValidity)), validFrom: certificate.tests?.first?.validFromDate, dateError: .EXPIRED)))
-                    case "RR-CH-0000": completionHandler(.failure(.NETWORK_PARSE_ERROR))
+                    case "RR-CH-0000": completionHandler(.failure(.TOO_MANY_RECOVERY_ENTRIES))
                     case "RR-CH-0001": completionHandler(.failure(.NO_VALID_DATE))
                     case "RR-CH-0002": completionHandler(.success(VerificationResult(isValid: false, validUntil: certificate.pastInfections?.first?.getValidUntilDate(maximumValidityInDays: Int(maxRecoveryValidity)), validFrom: certificate.pastInfections?.first?.validFromDate, dateError: .NOT_YET_VALID)))
                     case "RR-CH-0003": completionHandler(.success(VerificationResult(isValid: false, validUntil: certificate.pastInfections?.first?.getValidUntilDate(maximumValidityInDays: Int(maxRecoveryValidity)), validFrom: certificate.pastInfections?.first?.validFromDate, dateError: .EXPIRED)))

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
@@ -22,6 +22,9 @@ public enum NationalRulesError: Error, Equatable {
     case NETWORK_PARSE_ERROR
     case NETWORK_NO_INTERNET_CONNECTION(errorCode: String)
     case UNKNOWN_TEST_FAILURE
+    case TOO_MANY_VACCINE_ENTRIES
+    case TOO_MANY_TEST_ENTRIES
+    case TOO_MANY_RECOVERY_ENTRIES
 
     public var errorCode: String {
         switch self {
@@ -35,6 +38,9 @@ public enum NationalRulesError: Error, Equatable {
         case .NETWORK_PARSE_ERROR: return "NE|PE"
         case let .NETWORK_NO_INTERNET_CONNECTION(code): return code.count > 0 ? "NE|\(code)" : "NE|NIC"
         case .UNKNOWN_TEST_FAILURE: return "N|UKN"
+        case .TOO_MANY_VACCINE_ENTRIES: return "N|TMVE"
+        case .TOO_MANY_TEST_ENTRIES: return "N|TMTE"
+        case .TOO_MANY_RECOVERY_ENTRIES: return "N|TMRE"
         }
     }
 }


### PR DESCRIPTION
Previously network error was used on accident. Since a certificate with more entries is not yet decodable this error never is surfaced.