### PR TITLE
Fix display rule caching / offline mode

### DIFF
--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
@@ -23,6 +23,7 @@ class NationalRulesList: Codable, JWTExtension {
             } else {
                 rules = nil
                 valueSets = nil
+                displayRules = nil
             }
         }
     }
@@ -47,6 +48,8 @@ class NationalRulesList: Codable, JWTExtension {
         if let newValue = requestData {
             rules = JSON(newValue)["rules"]
             valueSets = JSON(newValue)["valueSets"]
+            displayRules = JSON(newValue)["displayRules"]
+
         }
     }
 

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesList.swift
@@ -46,10 +46,10 @@ class NationalRulesList: Codable, JWTExtension {
         requestData = try? container.decode(Data.self, forKey: .requestData)
 
         if let newValue = requestData {
-            rules = JSON(newValue)["rules"]
-            valueSets = JSON(newValue)["valueSets"]
-            displayRules = JSON(newValue)["displayRules"]
-
+            let json = JSON(newValue)
+            rules = json["rules"]
+            valueSets = json["valueSets"]
+            displayRules = json["displayRules"]
         }
     }
 


### PR DESCRIPTION
This pull-request fixes display rule caching and makes sure the SDK can be used offline (as long as cached data is not older than 48h).