### PR TITLE
Feature: Add time shift detection

### DIFF
--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -130,6 +130,12 @@ struct CovidCertificateImpl {
         }
 
         trustListManager.trustCertificateUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
+            // If there is a time inconsistency between server and device, this error takes priority even if there's a valid list
+            if case .TIME_INCONSISTENCY = lastError, let e = lastError?.asValidationError() {
+                completionHandler(.failure(e))
+                return
+            }
+
             // Safe-guard that we have a recent trust list available at this point
             guard trustListManager.trustStorage.certificateListIsValid() else {
                 if let e = lastError?.asValidationError() {
@@ -174,6 +180,11 @@ struct CovidCertificateImpl {
 
     func checkRevocationStatus(certificate: DCCCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
         trustListManager.revocationListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
+            // If there is a time inconsistency between server and device, this error takes priority even if there's a valid list
+            if case .TIME_INCONSISTENCY = lastError, let e = lastError?.asValidationError() {
+                completionHandler(.failure(e))
+                return
+            }
 
             // Safe-guard that we have a recent revocation list available at this point
             guard trustListManager.trustStorage.revocationListIsValid() else {
@@ -202,6 +213,11 @@ struct CovidCertificateImpl {
         }
 
         trustListManager.nationalRulesListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
+            // If there is a time inconsistency between server and device, this error takes priority even if there's a valid list
+            if case .TIME_INCONSISTENCY = lastError, let e = lastError?.asNationalRulesError() {
+                completionHandler(.failure(e))
+                return
+            }
 
             // Safe-guard that we have a recent national rules list available at this point
             guard trustListManager.trustStorage.nationalRulesListIsStillValid() else {

--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -91,5 +91,6 @@ public enum CovidCertificateSDK {
 
     public static func setOptions(options: SDKOptions) {
         URLSession.evaluator.useCertificatePinning = options.certificatePinning
+        TrustListUpdate.allowedServerTimeDiff = options.allowedServerTimeDiff
     }
 }

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
@@ -21,6 +21,7 @@ public enum NationalRulesError: Error, Equatable {
     case NETWORK_ERROR(errorCode: String)
     case NETWORK_PARSE_ERROR
     case NETWORK_NO_INTERNET_CONNECTION(errorCode: String)
+    case TIME_INCONSISTENCY(timeShift: TimeInterval)
     case UNKNOWN_TEST_FAILURE
     case TOO_MANY_VACCINE_ENTRIES
     case TOO_MANY_TEST_ENTRIES
@@ -37,6 +38,7 @@ public enum NationalRulesError: Error, Equatable {
         case let .NETWORK_ERROR(code): return code.count > 0 ? "NE|\(code)" : "NE"
         case .NETWORK_PARSE_ERROR: return "NE|PE"
         case let .NETWORK_NO_INTERNET_CONNECTION(code): return code.count > 0 ? "NE|\(code)" : "NE|NIC"
+        case .TIME_INCONSISTENCY: return "NE|TI"
         case .UNKNOWN_TEST_FAILURE: return "N|UKN"
         case .TOO_MANY_VACCINE_ENTRIES: return "N|TMVE"
         case .TOO_MANY_TEST_ENTRIES: return "N|TMTE"

--- a/Sources/CovidCertificateSDK/Networking/Endpoint.swift
+++ b/Sources/CovidCertificateSDK/Networking/Endpoint.swift
@@ -82,4 +82,22 @@ extension HTTPURLResponse {
             return nil
         }
     }
+
+    private static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'"
+        formatter.timeZone = TimeZone(abbreviation: "GMT")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter
+    }()
+
+    var date: Date? {
+        guard let string = value(forHeaderField: "date") else { return nil }
+        return HTTPURLResponse.dateFormatter.date(from: string)
+    }
+
+    var age: TimeInterval {
+        guard let string = value(forHeaderField: "Age") else { return 0 }
+        return TimeInterval(string) ?? 0
+    }
 }

--- a/Sources/CovidCertificateSDK/SDKOptions.swift
+++ b/Sources/CovidCertificateSDK/SDKOptions.swift
@@ -12,10 +12,16 @@ import Foundation
 
 /// Configure advanced options of the SDK
 public struct SDKOptions {
-    /// Option to disable certificate pinning of TLS requests for debugging
-    var certificatePinning = true
+    public static let defaultAllowedServerTimeDiff: TimeInterval = 60 * 60 * 2
 
-    public init(certificatePinning: Bool) {
+    /// Option to disable certificate pinning of TLS requests for debugging
+    public var certificatePinning: Bool
+
+    /// The server time difference that devices are allowed to have without showing a warning
+    public var allowedServerTimeDiff: TimeInterval
+
+    public init(certificatePinning: Bool = true, allowedServerTimeDiff: TimeInterval = Self.defaultAllowedServerTimeDiff) {
         self.certificatePinning = certificatePinning
+        self.allowedServerTimeDiff = allowedServerTimeDiff
     }
 }

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
@@ -21,7 +21,11 @@ class NationalRulesListUpdate: TrustListUpdate {
 
     override func synchronousUpdate(ignoreLocalCache: Bool = false) -> NetworkError? {
         let request = CovidCertificateSDK.currentEnvironment.nationalRulesListService.request(reloadIgnoringLocalCache: ignoreLocalCache)
-        let (data, _, error) = session.synchronousDataTask(with: request)
+        let (data, response, error) = session.synchronousDataTask(with: request)
+
+        if let httpResponse = response as? HTTPURLResponse, let timeShiftError = detectTimeshift(response: httpResponse) {
+            return timeShiftError
+        }
 
         if error != nil {
             return error?.asNetworkError()

--- a/Sources/CovidCertificateSDK/TrustList/NetworkError.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NetworkError.swift
@@ -15,13 +15,18 @@ public enum NetworkError: Error, Equatable {
     case NETWORK_ERROR(errorCode: String)
     case NETWORK_PARSE_ERROR
     case NETWORK_NO_INTERNET_CONNECTION(errorCode: String)
+    case TIME_INCONSISTENCY(timeShift: TimeInterval)
 
     public var message: String {
         switch self {
-        case .NETWORK_ERROR: return "A network error occured"
-        case .NETWORK_PARSE_ERROR: return "The data could not be parsed"
+        case .NETWORK_ERROR:
+            return "A network error occured"
+        case .NETWORK_PARSE_ERROR:
+            return "The data could not be parsed"
         case .NETWORK_NO_INTERNET_CONNECTION:
             return "The internet connection appears to be offline"
+        case .TIME_INCONSISTENCY:
+            return "There seems to be a time inconsistency"
         }
     }
 
@@ -30,6 +35,7 @@ public enum NetworkError: Error, Equatable {
         case let .NETWORK_ERROR(code): return code.count > 0 ? "NE|\(code)" : "NE"
         case .NETWORK_PARSE_ERROR: return "NE|PE"
         case let .NETWORK_NO_INTERNET_CONNECTION(code): return code.count > 0 ? "NE|\(code)" : "NE|NIC"
+        case .TIME_INCONSISTENCY: return "NE|TI"
         }
     }
 }
@@ -57,12 +63,14 @@ extension Error {
 extension NetworkError {
     func asValidationError() -> ValidationError {
         switch self {
-        case let .NETWORK_ERROR(errorCode: errorCode):
+        case let .NETWORK_ERROR(errorCode):
             return .NETWORK_ERROR(errorCode: errorCode)
         case .NETWORK_PARSE_ERROR:
             return .NETWORK_PARSE_ERROR
-        case let .NETWORK_NO_INTERNET_CONNECTION(errorCode: errorCode):
+        case let .NETWORK_NO_INTERNET_CONNECTION(errorCode):
             return .NETWORK_NO_INTERNET_CONNECTION(errorCode: errorCode)
+        case let .TIME_INCONSISTENCY(timeShift):
+            return .TIME_INCONSISTENCY(timeShift: timeShift)
         }
     }
 }
@@ -70,12 +78,14 @@ extension NetworkError {
 extension NetworkError {
     func asNationalRulesError() -> NationalRulesError {
         switch self {
-        case let .NETWORK_ERROR(errorCode: errorCode):
+        case let .NETWORK_ERROR(errorCode):
             return .NETWORK_ERROR(errorCode: errorCode)
         case .NETWORK_PARSE_ERROR:
             return .NETWORK_PARSE_ERROR
-        case let .NETWORK_NO_INTERNET_CONNECTION(errorCode: errorCode):
+        case let .NETWORK_NO_INTERNET_CONNECTION(errorCode):
             return .NETWORK_NO_INTERNET_CONNECTION(errorCode: errorCode)
+        case let .TIME_INCONSISTENCY(timeShift):
+            return .TIME_INCONSISTENCY(timeShift: timeShift)
         }
     }
 }

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -38,6 +38,10 @@ class RevocationListUpdate: TrustListUpdate {
             let request = CovidCertificateSDK.currentEnvironment.revocationListService(since: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
             let (data, response, error) = session.synchronousDataTask(with: request)
 
+            if let httpResponse = response as? HTTPURLResponse, let timeShiftError = detectTimeshift(response: httpResponse) {
+                return timeShiftError
+            }
+
             if error != nil {
                 return error?.asNetworkError()
             }

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -27,6 +27,10 @@ class TrustCertificatesUpdate: TrustListUpdate {
         let requestActive = CovidCertificateSDK.currentEnvironment.activeCertificatesService.request(reloadIgnoringLocalCache: ignoreLocalCache)
         let (dataActive, response, errorActive) = session.synchronousDataTask(with: requestActive)
 
+        if let httpResponse = response as? HTTPURLResponse, let timeShiftError = detectTimeshift(response: httpResponse) {
+            return timeShiftError
+        }
+
         if errorActive != nil {
             return errorActive?.asNetworkError()
         }
@@ -64,6 +68,10 @@ class TrustCertificatesUpdate: TrustListUpdate {
                 .trustCertificatesService(since: trustStorage.certificateSince(), upTo: upTo)
                 .request(reloadIgnoringLocalCache: ignoreLocalCache)
             let (data, response, error) = session.synchronousDataTask(with: request)
+
+            if let httpResponse = response as? HTTPURLResponse, let timeShiftError = detectTimeshift(response: httpResponse) {
+                return timeShiftError
+            }
 
             if error != nil {
                 return error?.asNetworkError()

--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -188,8 +188,7 @@ class TrustListUpdate {
         }
     }
 
-    // TODO: Read value from config request
-    private static let allowedServerTimeDiff: TimeInterval = 60 * 10 // 10 minutes
+    static var allowedServerTimeDiff: TimeInterval = SDKOptions.defaultAllowedServerTimeDiff
 
     func detectTimeshift(response: HTTPURLResponse) -> NetworkError? {
         guard let date = response.date else { return nil }

--- a/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListManager.swift
@@ -183,7 +183,10 @@ class TrustListUpdate {
 
     private func startForceUpdate() {
         internalQueue.sync {
-            lastError = synchronousUpdate(ignoreLocalCache: true)
+            let error = synchronousUpdate(ignoreLocalCache: true)
+            operationQueue.addOperation {
+                self.lastError = error
+            }
             forceUpdateOperation = nil
         }
     }

--- a/Sources/CovidCertificateSDK/ehn/ValidationError.swift
+++ b/Sources/CovidCertificateSDK/ehn/ValidationError.swift
@@ -44,6 +44,7 @@ public enum ValidationError: Error, Equatable {
     case NETWORK_ERROR(errorCode: String)
     case NETWORK_PARSE_ERROR
     case NETWORK_NO_INTERNET_CONNECTION(errorCode: String)
+    case TIME_INCONSISTENCY(timeShift: TimeInterval)
 
     public var message: String {
         switch self {
@@ -64,6 +65,7 @@ public enum ValidationError: Error, Equatable {
         case .NETWORK_ERROR: return "A network error occured"
         case .NETWORK_PARSE_ERROR: return "The data could not be parsed"
         case .NETWORK_NO_INTERNET_CONNECTION: return "The internet connection appears to be offline"
+        case .TIME_INCONSISTENCY: return "There seems to be a time inconsistency"
         }
     }
 
@@ -86,6 +88,7 @@ public enum ValidationError: Error, Equatable {
         case let .NETWORK_ERROR(code): return code.count > 0 ? "NE|\(code)" : "NE"
         case .NETWORK_PARSE_ERROR: return "NE|PE"
         case let .NETWORK_NO_INTERNET_CONNECTION(code): return code.count > 0 ? "NE|\(code)" : "NE|NIC"
+        case .TIME_INCONSISTENCY: return "NE|TI"
         }
     }
 }


### PR DESCRIPTION
With this change, the SDK detects during every check (trust list, revocation list, national rules) whether the device time significantly differs from the server time and if so, returns a new `TIME_INCONSISTENCY` error. The "Date" and "Age" headers from the HTTP response are used to determine the server time.