### PR TITLE
Feature: Add serological tests for antibody certificate (+ update pre-packaged rules)

### DIFF
--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -278,6 +278,10 @@ struct CovidCertificateImpl {
                     completionHandler(.success(VerificationResult(isValid: false, validUntil: validity?.until, validFrom: validity?.from, dateError: .EXPIRED)))
                 case "TR-CH-0007":
                     completionHandler(.success(VerificationResult(isValid: false, validUntil: validity?.until, validFrom: validity?.from, dateError: .EXPIRED)))
+                case "TR-CH-0008":
+                    completionHandler(.failure(.NEGATIVE_RESULT))
+                case "TR-CH-0009":
+                    completionHandler(.success(VerificationResult(isValid: false, validUntil: validity?.until, validFrom: validity?.from, dateError: .EXPIRED)))
                 case "RR-CH-0000": completionHandler(.failure(.TOO_MANY_RECOVERY_ENTRIES))
                 case "RR-CH-0001": completionHandler(.failure(.NO_VALID_DATE))
                 case "RR-CH-0002":

--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -267,6 +267,11 @@ struct CovidCertificateImpl {
                                                                   validUntil: validity?.until,
                                                                   validFrom: validity?.from,
                                                                   dateError: .EXPIRED)))
+                case "VR-CH-0007":
+                    completionHandler(.success(VerificationResult(isValid: false,
+                                                                  validUntil: validity?.until,
+                                                                  validFrom: validity?.from,
+                                                                  dateError: .EXPIRED)))
                 case "TR-CH-0000": completionHandler(.failure(.TOO_MANY_TEST_ENTRIES))
                 case "TR-CH-0001": completionHandler(.failure(.POSITIVE_RESULT))
                 case "TR-CH-0002": completionHandler(.failure(.WRONG_TEST_TYPE))

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesConstants.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesConstants.swift
@@ -23,6 +23,7 @@ enum Disease: String, Equatable {
 enum TestType: String, Equatable, Codable {
     case Rat = "LP217198-3"
     case Pcr = "LP6464-4"
+    case SeroPositive = "94504-8"
 }
 
 enum TestResult: String, Equatable, Codable {

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesConstants.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesConstants.swift
@@ -23,7 +23,7 @@ enum Disease: String, Equatable {
 enum TestType: String, Equatable, Codable {
     case Rat = "LP217198-3"
     case Pcr = "LP6464-4"
-    case SeroPositive = "94504-8"
+    case Serological = "94504-8"
 }
 
 enum TestResult: String, Equatable, Codable {

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
@@ -16,6 +16,7 @@ public enum NationalRulesError: Error, Equatable {
     case WRONG_DISEASE_TARGET
     case WRONG_TEST_TYPE
     case POSITIVE_RESULT
+    case NEGATIVE_RESULT
     case NOT_FULLY_PROTECTED
     case NO_VALID_DATE
     case NETWORK_ERROR(errorCode: String)
@@ -32,6 +33,7 @@ public enum NationalRulesError: Error, Equatable {
         case .WRONG_DISEASE_TARGET: return "N|WDT"
         case .WRONG_TEST_TYPE: return "N|WTT"
         case .POSITIVE_RESULT: return "N|PR"
+        case .NEGATIVE_RESULT: return "N|NR"
         case .NOT_FULLY_PROTECTED: return "N|NFP"
         case .NO_VALID_DATE: return "N|NVD"
         case let .NETWORK_ERROR(code): return code.count > 0 ? "NE|\(code)" : "NE"

--- a/Sources/CovidCertificateSDK/ehn/DCCCert.swift
+++ b/Sources/CovidCertificateSDK/ehn/DCCCert.swift
@@ -269,6 +269,10 @@ public struct Test: Codable {
         return result == TestResult.Negative.rawValue
     }
 
+    public var isSeroPositive: Bool {
+        return testType == TestType.SeroPositive.rawValue
+    }
+
     public var testType: String? {
         return ProductNameManager.shared.testTypeName(key: type)
     }

--- a/Sources/CovidCertificateSDK/ehn/DCCCert.swift
+++ b/Sources/CovidCertificateSDK/ehn/DCCCert.swift
@@ -269,8 +269,8 @@ public struct Test: Codable {
         return result == TestResult.Negative.rawValue
     }
 
-    public var isSeroPositive: Bool {
-        return testType == TestType.SeroPositive.rawValue
+    public var isSerologicalTest: Bool {
+        return testType == TestType.Serological.rawValue
     }
 
     public var testType: String? {

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -492,11 +492,12 @@ final class CovidCertificateSDKTests: XCTestCase {
         waitForExpectations(timeout: 60, handler: nil)
     }
 
-    func testTypeHasToBePcrOrRat() {
+    func testTypeHasToBePcrOrRatOrSerological() {
         let hcert_rat = generateTestCert(testType: TestType.Rat.rawValue, testResultType: TestResult.Negative, name: "1232", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(hour: -10))
 
         let successExpectation1 = expectation(description: "success")
         let successExpectation2 = expectation(description: "success")
+        let successExpectation3 = expectation(description: "success")
         let failExpectation = expectation(description: "fail")
 
         verifier.checkNationalRules(certificate: hcert_rat, forceUpdate: false) { result in
@@ -508,6 +509,7 @@ final class CovidCertificateSDKTests: XCTestCase {
             }
             successExpectation1.fulfill()
         }
+
         let hcert_pcr = generateTestCert(testType: TestType.Pcr.rawValue, testResultType: TestResult.Negative, name: "Nucleic acid amplification with probe detection", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(hour: -10))
 
         verifier.checkNationalRules(certificate: hcert_pcr, forceUpdate: false) { result in
@@ -518,6 +520,18 @@ final class CovidCertificateSDKTests: XCTestCase {
                 XCTFail("Correct test should be ok")
             }
             successExpectation2.fulfill()
+        }
+
+        let hcert_sero = generateTestCert(testType: TestType.Serological.rawValue, testResultType: TestResult.Positive, name: "Serological", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(hour: -10))
+
+        verifier.checkNationalRules(certificate: hcert_sero, forceUpdate: false) { result in
+            switch result {
+            case let .success(r):
+                XCTAssertTrue(r.isValid)
+            default:
+                XCTFail("Correct test should be ok")
+            }
+            successExpectation3.fulfill()
         }
 
         let invalid_cert = generateTestCert(testType: "asdbas", testResultType: TestResult.Negative, name: "Nucleic acid amplification with probe detection", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(hour: -10))
@@ -536,7 +550,7 @@ final class CovidCertificateSDKTests: XCTestCase {
     }
 
     func testPcrTestsAreAlwaysAccepted() {
-        // pcr tests are always accepte
+        // pcr tests are always accepted
         let invalid_cert_pcr = generateTestCert(testType: TestType.Pcr.rawValue, testResultType: TestResult.Negative, name: "abcdef", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(hour: -10))
         let expectation = self.expectation(description: "async task")
 
@@ -654,6 +668,69 @@ final class CovidCertificateSDKTests: XCTestCase {
         waitForExpectations(timeout: 60, handler: nil)
     }
 
+    func testSeroResultHasToBePositive() {
+        let hcert_sero = generateTestCert(testType: TestType.Serological.rawValue, testResultType: TestResult.Negative, name: "1232", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(hour: -23))
+        let failExpectation = expectation(description: "fail")
+        let successExpectation = expectation(description: "success")
+
+        verifier.checkNationalRules(certificate: hcert_sero, forceUpdate: false) { result in
+            switch result {
+            case .failure(.NEGATIVE_RESULT):
+                XCTAssertTrue(true)
+            default:
+                XCTFail("Negative Result should fail")
+            }
+            failExpectation.fulfill()
+        }
+
+        let hcert_sero2 = generateTestCert(testType: TestType.Serological.rawValue, testResultType: TestResult.Positive, name: "1232", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(hour: -23))
+        verifier.checkNationalRules(certificate: hcert_sero2, forceUpdate: false) { result in
+            switch result {
+            case let .success(r):
+                XCTAssertTrue(r.isValid)
+            default:
+                XCTFail("Positive Result should be ok")
+            }
+            successExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+    func testSeroTestIsValidFor90Days() {
+        let hcert = generateTestCert(testType: TestType.Serological.rawValue, testResultType: TestResult.Positive, name: "1232", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(day: -89))
+
+        let correctExpectation = expectation(description: "correct")
+        verifier.checkNationalRules(certificate: hcert, forceUpdate: false) { result in
+            switch result {
+            case let .success(r):
+                /// TEST MUST BE VALID
+                XCTAssertTrue(r.isValid)
+            default:
+                XCTFail("Something happened")
+            }
+            correctExpectation.fulfill()
+        }
+
+        let invalid_hcert = generateTestCert(testType: TestType.Serological.rawValue, testResultType: TestResult.Positive, name: "1232", disease: Disease.SarsCov2.rawValue, sampleCollectionWasAgo: DateComponents(day: -90))
+
+        let wrongExpectation = expectation(description: "wrong")
+        verifier.checkNationalRules(certificate: invalid_hcert, forceUpdate: false) { result in
+            switch result {
+            case let .success(r):
+                /// TEST MUST BE INVALID
+                DispatchQueue.main.async {
+                    XCTAssertFalse(r.isValid)
+                }
+            default:
+                XCTFail("Something happened")
+            }
+            wrongExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
     /// RECOVERY TESTS
     private func getCalendar() -> Calendar {
         let utc = TimeZone(identifier: "UTC")!
@@ -766,9 +843,9 @@ final class CovidCertificateSDKTests: XCTestCase {
         XCTAssertTrue(calculatedValidUntil.isBefore(dayAfterTrueValidUntil))
     }
 
-    func testCertificateIsValidFor180DaysAfterTestResult() {
-        // The certificate was issued 179 days ago, which means it is still valid today (the 180th day)
-        let hcert = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -179), tg: Disease.SarsCov2.rawValue)
+    func testCertificateIsValidFor365DaysAfterTestResult() {
+        // The certificate was issued 364 days ago, which means it is still valid today (the 365th day)
+        let hcert = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -364), tg: Disease.SarsCov2.rawValue)
 
         let successExpectation = expectation(description: "success")
         let failExpectation = expectation(description: "fail")
@@ -783,8 +860,8 @@ final class CovidCertificateSDKTests: XCTestCase {
             }
             successExpectation.fulfill()
         }
-        // the certificate should not be valid anymore, since it was issued yesterday 179 days ago (hence yesterday was the 180th day)
-        let hcert_invalid = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -180), tg: Disease.SarsCov2.rawValue)
+        // the certificate should not be valid anymore, since it was issued yesterday 364 days ago (hence yesterday was the 365th day)
+        let hcert_invalid = generateRecoveryCert(validSinceNow: DateComponents(day: -10), validFromNow: DateComponents(month: 0), firstResultWasAgo: DateComponents(day: -365), tg: Disease.SarsCov2.rawValue)
         verifier.checkNationalRules(certificate: hcert_invalid, forceUpdate: false) { result in
             switch result {
             case let .success(r):

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -368,9 +368,9 @@ final class CovidCertificateSDKTests: XCTestCase {
             case let .success(r):
                 XCTAssertTrue(r.isValid)
                 XCTAssertTrue(self.areSameVaccineDates(r.validFrom!, today))
-                XCTAssertTrue(self.areSameVaccineDates(r.validUntil!, Calendar.current.date(byAdding: DateComponents(day: 364), to: time)!))
+                XCTAssertTrue(self.areSameVaccineDates(r.validUntil!, Calendar.current.date(byAdding: DateComponents(day: 364 + 22), to: time)!))
             default:
-                XCTFail("Should be vali")
+                XCTFail("Should be valid")
             }
             successExpectation.fulfill()
         }

--- a/Tests/CovidCertificateSDKTests/NationalRules/nationalrules.json
+++ b/Tests/CovidCertificateSDKTests/NationalRules/nationalrules.json
@@ -97,12 +97,47 @@
                         "var": "payload.v.0"
                     },
                     {
-                        "plusTime": [
+                        "if": [
                             {
-                                "var": "payload.v.0.dt"
+                                "and": [
+                                    {
+                                        "in": [
+                                            {
+                                                "var": "payload.v.0.mp"
+                                            },
+                                            [
+                                                "EU/1/20/1525"
+                                            ]
+                                        ]
+                                    },
+                                    {
+                                        "===": [
+                                            {
+                                                "var": "payload.v.0.dn"
+                                            },
+                                            1
+                                        ]
+                                    }
+                                ]
                             },
-                            364,
-                            "day"
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.v.0.dt"
+                                    },
+                                    386,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.v.0.dt"
+                                    },
+                                    364,
+                                    "day"
+                                ]
+                            }
                         ]
                     },
                     {
@@ -149,7 +184,28 @@
                                                 ]
                                             },
                                             {
-                                                "var": "undefined"
+                                                "if": [
+                                                    {
+                                                        "===": [
+                                                            {
+                                                                "var": "payload.t.0.tt"
+                                                            },
+                                                            "94504-8"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "plusTime": [
+                                                            {
+                                                                "var": "payload.t.0.sc"
+                                                            },
+                                                            89,
+                                                            "day"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "var": "undefined"
+                                                    }
+                                                ]
                                             }
                                         ]
                                     }
@@ -165,7 +221,7 @@
                                             {
                                                 "var": "payload.r.0.fr"
                                             },
-                                            179,
+                                            364,
                                             "day"
                                         ]
                                     },
@@ -178,1096 +234,6 @@
                     }
                 ]
             }
-        }
-    ],
-    "rules": [
-        {
-            "affectedFields": [
-                "r.0",
-                "r.0.tg",
-                "t.0",
-                "t.0.tg",
-                "v.0",
-                "v.0.tg"
-            ],
-            "certificateType": "General",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "The targeted disease agent must be COVID-19 of the value set list.",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "GR-CH-0001",
-            "logic": {
-                "and": [
-                    {
-                        "if": [
-                            {
-                                "var": "payload.r.0"
-                            },
-                            {
-                                "in": [
-                                    {
-                                        "var": "payload.r.0.tg"
-                                    },
-                                    [
-                                        "840539006"
-                                    ]
-                                ]
-                            },
-                            true
-                        ]
-                    },
-                    {
-                        "if": [
-                            {
-                                "var": "payload.t.0"
-                            },
-                            {
-                                "in": [
-                                    {
-                                        "var": "payload.t.0.tg"
-                                    },
-                                    [
-                                        "840539006"
-                                    ]
-                                ]
-                            },
-                            true
-                        ]
-                    },
-                    {
-                        "if": [
-                            {
-                                "var": "payload.v.0"
-                            },
-                            {
-                                "in": [
-                                    {
-                                        "var": "payload.v.0.tg"
-                                    },
-                                    [
-                                        "840539006"
-                                    ]
-                                ]
-                            },
-                            true
-                        ]
-                    }
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.1",
-                "r.0",
-                "t.0"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "At most one v-event.",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0000",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.v.0"
-                    },
-                    {
-                        "if": [
-                            {
-                                "and": [
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.v.1"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.r.0"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.t.0"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            true,
-                            false
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.0.dn",
-                "v.0.sd"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "Vaccination doses must be equal or greater than expected doses.",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0001",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.v.0"
-                    },
-                    {
-                        ">=": [
-                            {
-                                "var": "payload.v.0.dn"
-                            },
-                            {
-                                "var": "payload.v.0.sd"
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.0.mp"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "Only vaccines in the allowed valueset that have been approved by the EMA are allowed.",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0002",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.v.0"
-                    },
-                    {
-                        "in": [
-                            {
-                                "var": "payload.v.0.mp"
-                            },
-                            [
-                                "EU/1/20/1528",
-                                "EU/1/20/1507",
-                                "EU/1/21/1529",
-                                "EU/1/20/1525"
-                            ]
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.0.dt"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "Date of vaccination must exist",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0003",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.v.0"
-                    },
-                    {
-                        "var": "payload.v.0.dt"
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.0.mp",
-                "v.0.dt"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "If the vaccine requires two doses, the vaccination date must be before today",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0004",
-            "logic": {
-                "if": [
-                    {
-                        "and": [
-                            {
-                                "var": "payload.v.0"
-                            },
-                            {
-                                "in": [
-                                    {
-                                        "var": "payload.v.0.mp"
-                                    },
-                                    [
-                                        "EU/1/20/1528",
-                                        "EU/1/20/1507",
-                                        "EU/1/21/1529"
-                                    ]
-                                ]
-                            }
-                        ]
-                    },
-                    {
-                        "not-before": [
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "external.validationClockAtStartOfDay"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            },
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "payload.v.0.dt"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.0.mp",
-                "v.0.dn",
-                "v.0.dt"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days ",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0005",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.v.0"
-                    },
-                    {
-                        "if": [
-                            {
-                                "and": [
-                                    {
-                                        "in": [
-                                            {
-                                                "var": "payload.v.0.mp"
-                                            },
-                                            [
-                                                "EU/1/20/1525"
-                                            ]
-                                        ]
-                                    },
-                                    {
-                                        "===": [
-                                            {
-                                                "var": "payload.v.0.dn"
-                                            },
-                                            1
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "not-before": [
-                                    {
-                                        "plusTime": [
-                                            {
-                                                "var": "external.validationClockAtStartOfDay"
-                                            },
-                                            0,
-                                            "day"
-                                        ]
-                                    },
-                                    {
-                                        "plusTime": [
-                                            {
-                                                "var": "payload.v.0.dt"
-                                            },
-                                            21,
-                                            "day"
-                                        ]
-                                    }
-                                ]
-                            },
-                            true
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.0.dt"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "Today must be less than the vaccination date plus 364 days",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0006",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.v.0"
-                    },
-                    {
-                        "not-after": [
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "external.validationClockAtStartOfDay"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            },
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "payload.v.0.dt"
-                                    },
-                                    364,
-                                    "day"
-                                ]
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "v.0",
-                "v.0.mp",
-                "v.0.dn",
-                "v.0.dt"
-            ],
-            "certificateType": "Vaccination",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today ",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "VR-CH-0007",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.v.0"
-                    },
-                    {
-                        "if": [
-                            {
-                                "and": [
-                                    {
-                                        "in": [
-                                            {
-                                                "var": "payload.v.0.mp"
-                                            },
-                                            [
-                                                "EU/1/20/1525"
-                                            ]
-                                        ]
-                                    },
-                                    {
-                                        ">": [
-                                            {
-                                                "var": "payload.v.0.dn"
-                                            },
-                                            1
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "not-before": [
-                                    {
-                                        "plusTime": [
-                                            {
-                                                "var": "external.validationClockAtStartOfDay"
-                                            },
-                                            0,
-                                            "day"
-                                        ]
-                                    },
-                                    {
-                                        "plusTime": [
-                                            {
-                                                "var": "payload.v.0.dt"
-                                            },
-                                            0,
-                                            "day"
-                                        ]
-                                    }
-                                ]
-                            },
-                            true
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "t.0",
-                "t.1",
-                "r.0",
-                "v.0"
-            ],
-            "certificateType": "Test",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "At most one t-event.",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "TR-CH-0000",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.t.0"
-                    },
-                    {
-                        "if": [
-                            {
-                                "and": [
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.t.1"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.r.0"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.v.0"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            true,
-                            false
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "t.0",
-                "t.0.tr"
-            ],
-            "certificateType": "Test",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "Test result must be negative (\"not detected\").",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "TR-CH-0001",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.t.0"
-                    },
-                    {
-                        "===": [
-                            {
-                                "var": "payload.t.0.tr"
-                            },
-                            "260415000"
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "t.0",
-                "t.0.tt"
-            ],
-            "certificateType": "Test",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "The test type must be one of the value set list (RAT OR NAA).",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "TR-CH-0002",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.t.0"
-                    },
-                    {
-                        "in": [
-                            {
-                                "var": "payload.t.0.tt"
-                            },
-                            [
-                                "LP217198-3",
-                                "LP6464-4"
-                            ]
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "t.0",
-                "t.0.sc"
-            ],
-            "certificateType": "Test",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "Date of sample collection must exist",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "TR-CH-0004",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.t.0"
-                    },
-                    {
-                        "var": "payload.t.0.sc"
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "t.0",
-                "t.0.sc"
-            ],
-            "certificateType": "Test",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "The date of sample collection must be before the validation date",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "TR-CH-0005",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.t.0"
-                    },
-                    {
-                        "before": [
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "payload.t.0.sc"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            },
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "external.validationClock"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "t.0.tt",
-                "t.0.sc"
-            ],
-            "certificateType": "Test",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "If the test type is \"RAT\" then the validation date must be before the date of sample collection plus 48 hours",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "TR-CH-0006",
-            "logic": {
-                "if": [
-                    {
-                        "===": [
-                            {
-                                "var": "payload.t.0.tt"
-                            },
-                            "LP217198-3"
-                        ]
-                    },
-                    {
-                        "before": [
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "external.validationClock"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            },
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "payload.t.0.sc"
-                                    },
-                                    48,
-                                    "hour"
-                                ]
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "t.0.tt",
-                "t.0.sc"
-            ],
-            "certificateType": "Test",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "If the test type is \"PCR\" then the validation date must be before the date of sample collection plus 72 hours",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "TR-CH-0007",
-            "logic": {
-                "if": [
-                    {
-                        "===": [
-                            {
-                                "var": "payload.t.0.tt"
-                            },
-                            "LP6464-4"
-                        ]
-                    },
-                    {
-                        "before": [
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "external.validationClock"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            },
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "payload.t.0.sc"
-                                    },
-                                    72,
-                                    "hour"
-                                ]
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "r.0",
-                "r.1",
-                "v.0",
-                "t.0"
-            ],
-            "certificateType": "Recovery",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "At most one r-event.",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "RR-CH-0000",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.r.0"
-                    },
-                    {
-                        "if": [
-                            {
-                                "and": [
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.r.1"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.v.0"
-                                            }
-                                        ]
-                                    },
-                                    {
-                                        "!": [
-                                            {
-                                                "var": "payload.t.0"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            },
-                            true,
-                            false
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "r.0",
-                "r.0.fr"
-            ],
-            "certificateType": "Recovery",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "Date of first positive test must exist",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "RR-CH-0001",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.r.0"
-                    },
-                    {
-                        "var": "payload.r.0.fr"
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "r.0",
-                "r.0.fr"
-            ],
-            "certificateType": "Recovery",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "The validation date must be after the date of first positive test plus 10 days",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "RR-CH-0002",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.r.0"
-                    },
-                    {
-                        "not-before": [
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "external.validationClockAtStartOfDay"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            },
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "payload.r.0.fr"
-                                    },
-                                    10,
-                                    "day"
-                                ]
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
-        },
-        {
-            "affectedFields": [
-                "r.0",
-                "r.0.fr"
-            ],
-            "certificateType": "Recovery",
-            "country": "CH",
-            "description": [
-                {
-                    "desc": "The validation date must be less than the date of first positive test plus 179 days",
-                    "lang": "en"
-                }
-            ],
-            "engine": "CertLogic",
-            "engineVersion": "0.7.5",
-            "identifier": "RR-CH-0003",
-            "logic": {
-                "if": [
-                    {
-                        "var": "payload.r.0"
-                    },
-                    {
-                        "not-after": [
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "external.validationClockAtStartOfDay"
-                                    },
-                                    0,
-                                    "day"
-                                ]
-                            },
-                            {
-                                "plusTime": [
-                                    {
-                                        "var": "payload.r.0.fr"
-                                    },
-                                    179,
-                                    "day"
-                                ]
-                            }
-                        ]
-                    },
-                    true
-                ]
-            },
-            "schemaVersion": "1.3.0",
-            "type": "Acceptance",
-            "validFrom": "2020-01-01T00:00:00Z",
-            "validTo": "2031-01-01T00:00:00Z",
-            "version": "1.0.0"
         }
     ],
     "validDuration": 172800000,
@@ -1521,7 +487,8 @@
             "YT",
             "ZA",
             "ZM",
-            "ZW"
+            "ZW",
+            "XK"
         ],
         "vaccines-covid-19-auth-holders": [
             "ORG-100001699",
@@ -1538,7 +505,11 @@
             "Vector-Institute",
             "Sinovac-Biotech",
             "Bharat-Biotech",
-            "ORG-100001981"
+            "ORG-100001981",
+            "Fiocruz",
+            "ORG-100007893",
+            "Chumakov-Federal-Scientific-Center",
+            "ORG-100023050"
         ],
         "disease-agent-targeted": [
             "840539006"
@@ -1565,7 +536,12 @@
             "Inactivated-SARS-CoV-2-Vero-Cell",
             "CoronaVac",
             "Covaxin",
-            "Covishield"
+            "Covishield",
+            "Covid-19-recombinant",
+            "R-COVI",
+            "CoviVac",
+            "Sputnik-Light",
+            "Hayat-Vax"
         ],
         "covid-19-lab-test-type": [
             "LP6464-4",
@@ -1711,7 +687,1345 @@
             "2241",
             "1762",
             "2290",
-            "1178"
+            "1178",
+            "2374",
+            "2579",
+            "2089",
+            "2494",
+            "1691",
+            "2150",
+            "1960",
+            "2273",
+            "2533",
+            "1929",
+            "1801",
+            "2278",
+            "2419",
+            "2144",
+            "2156",
+            "2415",
+            "2414",
+            "1813",
+            "2026",
+            "2297",
+            "2143",
+            "1902"
         ]
-    }
+    },
+    "rules": [
+        {
+            "affectedFields": [
+                "r.0",
+                "r.0.tg",
+                "t.0",
+                "t.0.tg",
+                "v.0",
+                "v.0.tg"
+            ],
+            "certificateType": "General",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "The targeted disease agent must be COVID-19 of the value set list.",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "GR-CH-0001",
+            "logic": {
+                "and": [
+                    {
+                        "if": [
+                            {
+                                "var": "payload.r.0"
+                            },
+                            {
+                                "in": [
+                                    {
+                                        "var": "payload.r.0.tg"
+                                    },
+                                    [
+                                        "840539006"
+                                    ]
+                                ]
+                            },
+                            true
+                        ]
+                    },
+                    {
+                        "if": [
+                            {
+                                "var": "payload.t.0"
+                            },
+                            {
+                                "in": [
+                                    {
+                                        "var": "payload.t.0.tg"
+                                    },
+                                    [
+                                        "840539006"
+                                    ]
+                                ]
+                            },
+                            true
+                        ]
+                    },
+                    {
+                        "if": [
+                            {
+                                "var": "payload.v.0"
+                            },
+                            {
+                                "in": [
+                                    {
+                                        "var": "payload.v.0.tg"
+                                    },
+                                    [
+                                        "840539006"
+                                    ]
+                                ]
+                            },
+                            true
+                        ]
+                    }
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "r.0",
+                "r.1",
+                "v.0",
+                "t.0"
+            ],
+            "certificateType": "Recovery",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "At most one r-event.",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "RR-CH-0000",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.r.0"
+                    },
+                    {
+                        "if": [
+                            {
+                                "and": [
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.r.1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.v.0"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.t.0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            true,
+                            false
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "r.0",
+                "r.0.fr"
+            ],
+            "certificateType": "Recovery",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "Date of first positive test must exist",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "RR-CH-0001",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.r.0"
+                    },
+                    {
+                        "!": [
+                            {
+                                "!": [
+                                    {
+                                        "var": "payload.r.0.fr"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "r.0",
+                "r.0.fr"
+            ],
+            "certificateType": "Recovery",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "The validation date must be after the date of first positive test plus 10 days",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "RR-CH-0002",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.r.0"
+                    },
+                    {
+                        "after": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.r.0.fr"
+                                    },
+                                    10,
+                                    "day"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "r.0",
+                "r.0.fr"
+            ],
+            "certificateType": "Recovery",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "The validation date must be before the date of first positive test plus 365 days",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "RR-CH-0003",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.r.0"
+                    },
+                    {
+                        "before": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.r.0.fr"
+                                    },
+                                    365,
+                                    "day"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0",
+                "t.1",
+                "r.0",
+                "v.0"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "At most one t-event.",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0000",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.t.0"
+                    },
+                    {
+                        "if": [
+                            {
+                                "and": [
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.t.1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.r.0"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.v.0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            true,
+                            false
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0",
+                "t.0.tr",
+                "t.0.tt"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "For rapid or PCR test, the result must be negative (\"not detected\").",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0001",
+            "logic": {
+                "if": [
+                    {
+                        "and": [
+                            {
+                                "var": "payload.t.0"
+                            },
+                            {
+                                "in": [
+                                    {
+                                        "var": "payload.t.0.tt"
+                                    },
+                                    [
+                                        "LP217198-3",
+                                        "LP6464-4"
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "===": [
+                            {
+                                "var": "payload.t.0.tr"
+                            },
+                            "260415000"
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0",
+                "t.0.tt"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "The test type must be one of the value set list (RAT OR NAA or serum antibody).",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0002",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.t.0"
+                    },
+                    {
+                        "in": [
+                            {
+                                "var": "payload.t.0.tt"
+                            },
+                            [
+                                "LP217198-3",
+                                "LP6464-4",
+                                "94504-8"
+                            ]
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0",
+                "t.0.sc"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "Date of sample collection must exist",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0004",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.t.0"
+                    },
+                    {
+                        "!": [
+                            {
+                                "!": [
+                                    {
+                                        "var": "payload.t.0.sc"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0",
+                "t.0.sc"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "The date of sample collection must be before the validation date",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0005",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.t.0"
+                    },
+                    {
+                        "before": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.t.0.sc"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0.tt",
+                "t.0.sc"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "If the test type is \"RAT\" then the validation date must be before the date of sample collection plus 48 hours",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0006",
+            "logic": {
+                "if": [
+                    {
+                        "===": [
+                            {
+                                "var": "payload.t.0.tt"
+                            },
+                            "LP217198-3"
+                        ]
+                    },
+                    {
+                        "before": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.t.0.sc"
+                                    },
+                                    48,
+                                    "hour"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0.tt",
+                "t.0.sc"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "If the test type is \"PCR\" then the validation date must be before the date of sample collection plus 72 hours",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0007",
+            "logic": {
+                "if": [
+                    {
+                        "===": [
+                            {
+                                "var": "payload.t.0.tt"
+                            },
+                            "LP6464-4"
+                        ]
+                    },
+                    {
+                        "before": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.t.0.sc"
+                                    },
+                                    72,
+                                    "hour"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0",
+                "t.0.tr",
+                "t.0.tt"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "For serum antibody tests, the result must be positive.",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0008",
+            "logic": {
+                "if": [
+                    {
+                        "and": [
+                            {
+                                "var": "payload.t.0"
+                            },
+                            {
+                                "in": [
+                                    {
+                                        "var": "payload.t.0.tt"
+                                    },
+                                    [
+                                        "94504-8"
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "===": [
+                            {
+                                "var": "payload.t.0.tr"
+                            },
+                            "260373001"
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "t.0.tt",
+                "t.0.sc"
+            ],
+            "certificateType": "Test",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "If the test is a serum antibody test, then the validation date must be before the date of sample collection plus 90 days",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "TR-CH-0009",
+            "logic": {
+                "if": [
+                    {
+                        "===": [
+                            {
+                                "var": "payload.t.0.tt"
+                            },
+                            "94504-8"
+                        ]
+                    },
+                    {
+                        "before": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.t.0.sc"
+                                    },
+                                    90,
+                                    "day"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.1",
+                "r.0",
+                "t.0"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "At most one v-event.",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0000",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.v.0"
+                    },
+                    {
+                        "if": [
+                            {
+                                "and": [
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.v.1"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.r.0"
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "!": [
+                                            {
+                                                "var": "payload.t.0"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            true,
+                            false
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.0.dn",
+                "v.0.sd"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "Vaccination doses must be equal or greater than expected doses.",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0001",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.v.0"
+                    },
+                    {
+                        ">=": [
+                            {
+                                "var": "payload.v.0.dn"
+                            },
+                            {
+                                "var": "payload.v.0.sd"
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.0.mp"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "Only vaccines in the allowed valueset that have been approved by the EMA are allowed.",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0002",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.v.0"
+                    },
+                    {
+                        "in": [
+                            {
+                                "var": "payload.v.0.mp"
+                            },
+                            [
+                                "EU/1/20/1528",
+                                "EU/1/20/1507",
+                                "EU/1/21/1529",
+                                "EU/1/20/1525",
+                                "CoronaVac",
+                                "BBIBP-CorV",
+                                "Covishield"
+                            ]
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.0.dt"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "Date of vaccination must exist",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0003",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.v.0"
+                    },
+                    {
+                        "!": [
+                            {
+                                "!": [
+                                    {
+                                        "var": "payload.v.0.dt"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.0.mp",
+                "v.0.dt"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "If the vaccine requires two doses, the vaccination date must be before today",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0004",
+            "logic": {
+                "if": [
+                    {
+                        "and": [
+                            {
+                                "var": "payload.v.0"
+                            },
+                            {
+                                "in": [
+                                    {
+                                        "var": "payload.v.0.mp"
+                                    },
+                                    [
+                                        "EU/1/20/1528",
+                                        "EU/1/20/1507",
+                                        "EU/1/21/1529"
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "not-after": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.v.0.dt"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.0.mp",
+                "v.0.dn",
+                "v.0.dt"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "If the vaccine requires one dose, and only one dose was administered, it is valid after 21 days and until 387 days later",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0005",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.v.0"
+                    },
+                    {
+                        "if": [
+                            {
+                                "and": [
+                                    {
+                                        "in": [
+                                            {
+                                                "var": "payload.v.0.mp"
+                                            },
+                                            [
+                                                "EU/1/20/1525"
+                                            ]
+                                        ]
+                                    },
+                                    {
+                                        "===": [
+                                            {
+                                                "var": "payload.v.0.dn"
+                                            },
+                                            1
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    {
+                                        "not-before": [
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "external.validationClock"
+                                                    },
+                                                    0,
+                                                    "day"
+                                                ]
+                                            },
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "payload.v.0.dt"
+                                                    },
+                                                    21,
+                                                    "day"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "before": [
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "external.validationClock"
+                                                    },
+                                                    0,
+                                                    "day"
+                                                ]
+                                            },
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "payload.v.0.dt"
+                                                    },
+                                                    387,
+                                                    "day"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            true
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.0.dt",
+                "v.0.mp"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "For 2/2 doses, the current date and time must be before the vaccination date plus 365 days for 2-dose vaccines",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0006",
+            "logic": {
+                "if": [
+                    {
+                        "and": [
+                            {
+                                "var": "payload.v.0"
+                            },
+                            {
+                                "in": [
+                                    {
+                                        "var": "payload.v.0.mp"
+                                    },
+                                    [
+                                        "EU/1/20/1528",
+                                        "EU/1/20/1507",
+                                        "EU/1/21/1529",
+                                        "CoronaVac",
+                                        "BBIBP-CorV",
+                                        "Covishield"
+                                    ]
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "before": [
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "external.validationClock"
+                                    },
+                                    0,
+                                    "day"
+                                ]
+                            },
+                            {
+                                "plusTime": [
+                                    {
+                                        "var": "payload.v.0.dt"
+                                    },
+                                    365,
+                                    "day"
+                                ]
+                            }
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        },
+        {
+            "affectedFields": [
+                "v.0",
+                "v.0.mp",
+                "v.0.dn",
+                "v.0.dt"
+            ],
+            "certificateType": "Vaccination",
+            "country": "CH",
+            "description": [
+                {
+                    "desc": "If the vaccine requires only one dose but more than one dose was administered, it is valid from today for 365 days",
+                    "lang": "en"
+                }
+            ],
+            "engine": "CertLogic",
+            "engineVersion": "0.7.5",
+            "identifier": "VR-CH-0007",
+            "logic": {
+                "if": [
+                    {
+                        "var": "payload.v.0"
+                    },
+                    {
+                        "if": [
+                            {
+                                "and": [
+                                    {
+                                        "in": [
+                                            {
+                                                "var": "payload.v.0.mp"
+                                            },
+                                            [
+                                                "EU/1/20/1525"
+                                            ]
+                                        ]
+                                    },
+                                    {
+                                        ">": [
+                                            {
+                                                "var": "payload.v.0.dn"
+                                            },
+                                            1
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "and": [
+                                    {
+                                        "not-before": [
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "external.validationClock"
+                                                    },
+                                                    0,
+                                                    "day"
+                                                ]
+                                            },
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "payload.v.0.dt"
+                                                    },
+                                                    0,
+                                                    "day"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "before": [
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "external.validationClock"
+                                                    },
+                                                    0,
+                                                    "day"
+                                                ]
+                                            },
+                                            {
+                                                "plusTime": [
+                                                    {
+                                                        "var": "payload.v.0.dt"
+                                                    },
+                                                    365,
+                                                    "day"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            true
+                        ]
+                    },
+                    true
+                ]
+            },
+            "schemaVersion": "1.0.0",
+            "type": "Acceptance",
+            "validFrom": "2021-10-18T12:00:00Z",
+            "validTo": "2031-01-01T00:00:00Z",
+            "version": "1.0.3"
+        }
+    ]
 }


### PR DESCRIPTION
This pull request adds support for serological tests (antibody based recovery certificate). It also updates the pre-packaged business rules.