### PR TITLE
Switzerland special cases

### DIFF
--- a/Sources/CovidCertificateSDK/Models/CovidCertificate.swift
+++ b/Sources/CovidCertificateSDK/Models/CovidCertificate.swift
@@ -15,6 +15,10 @@ public protocol CovidCertificate {
     var dateOfBirth: String { get }
     var version: String { get }
     var type: CertificateType { get }
+
+    /// Whether a certificate is a case only valid in Switzerland.
+    /// At the moment, this is true for light certificates and serological tests, false otherwise.
+    var isSwitzerlandOnly: Bool { get }
 }
 
 public extension CovidCertificate {

--- a/Sources/CovidCertificateSDK/Models/LightCert.swift
+++ b/Sources/CovidCertificateSDK/Models/LightCert.swift
@@ -31,4 +31,8 @@ public struct LightCert: CovidCertificate, Codable {
         version = try container.decode(String.self, forKey: .version)
         dateOfBirth = try container.decode(String.self, forKey: .dateOfBirth)
     }
+
+    public var isSwitzerlandOnly: Bool {
+        return true
+    }
 }

--- a/Sources/CovidCertificateSDK/ehn/Extensions.swift
+++ b/Sources/CovidCertificateSDK/ehn/Extensions.swift
@@ -71,4 +71,12 @@ extension DCCCert {
             return []
         }
     }
+
+    public var isSwitzerlandOnly: Bool {
+        if immunisationType == .test, let t = tests?.first {
+            return t.isSerologicalTest
+        }
+
+        return false
+    }
 }


### PR DESCRIPTION
This PR adds a `isSwitzerlandOnly` property to certificates that denotes whether this type of certificate is only valid in Switzerland.

Currently, this is true for the following two cases:
- Light Certificates
- Serological tests