### PR TITLE
Instruct URLSession/CFNetwork to add "If-None-Match" header 

### DIFF
--- a/Sources/CovidCertificateSDK/Networking/Endpoint.swift
+++ b/Sources/CovidCertificateSDK/Networking/Endpoint.swift
@@ -33,7 +33,12 @@ extension Endpoint {
         request.httpMethod = method.rawValue
 
         if reloadIgnoringLocalCache {
-            request.cachePolicy = .reloadIgnoringLocalCacheData
+            if #available(iOS 13, *) {
+                // Add Etag from cache to "If-None-Match" header
+                request.cachePolicy = .reloadRevalidatingCacheData
+            } else {
+                request.cachePolicy = .reloadIgnoringLocalCacheData
+            }
         }
 
         request.setValue(userAgentHeader, forHTTPHeaderField: "User-Agent")


### PR DESCRIPTION
Using `.reloadRevalidatingCacheData` consistently adds the `If-None-Match` HTTP header to requests with cached Etags whereas `.reloadIgnoringLocalCacheData` only seems to do so in certain (?) cases. Unfortunately `.reloadRevalidatingCacheData` was only added with iOS 13.