### PR TITLE
Get isSwitzerlandOnly from displayRules

### DIFF
--- a/Sources/CovidCertificateSDK/CertLogic/CertLogic.swift
+++ b/Sources/CovidCertificateSDK/CertLogic/CertLogic.swift
@@ -22,14 +22,10 @@ enum CertLogicValidationError: Error {
     case TEST_COULD_NOT_BE_PERFORMED(test: String)
 }
 
-class Validity {
-    let from: Date
-    let until: Date
-
-    init(from: Date, until: Date) {
-        self.from = from
-        self.until = until
-    }
+struct DisplayRulesResult {
+    let validFrom: Date?
+    let validUntil: Date?
+    let isSwitzerlandOnly: Bool?
 }
 
 class CertLogic {
@@ -86,7 +82,7 @@ class CertLogic {
         }
     }
 
-    func getValidity(hcert: DCCCert, validationClock: Date = Date()) -> Result<Validity, CertLogicValidationError> {
+    func checkDisplayRules(hcert: DCCCert, validationClock: Date = Date()) -> Result<DisplayRulesResult, CertLogicValidationError> {
         let external = externalJson(validationClock: validationClock)
 
         guard let dccJson = try? JSONEncoder().encode(hcert) else {
@@ -97,60 +93,36 @@ class CertLogic {
 
         var startDate: Date?
         var endDate: Date?
-
-        for displayRule in displayRules {
-            // get from date
-            if displayRule["id"] == "display-from-date" {
-                guard let result: Date = try? applyRule(displayRule["logic"], to: context) else {
-                    return .failure(.TEST_COULD_NOT_BE_PERFORMED(test: displayRule["id"].string ?? "VALIDITY_TEST"))
-                }
-
-                startDate = result
-            }
-
-            // get end date
-            if displayRule["id"] == "display-until-date" {
-                guard let result: Date = try? applyRule(displayRule["logic"], to: context) else {
-                    return .failure(.TEST_COULD_NOT_BE_PERFORMED(test: displayRule["id"].string ?? "VALIDITY_TEST"))
-                }
-
-                endDate = result
-            }
-        }
-
-        guard let s = startDate,
-              let e = endDate else {
-            return .failure(.TEST_COULD_NOT_BE_PERFORMED(test: "VALIDITY_TEST"))
-        }
-
-        return .success(Validity(from: s, until: e))
-    }
-
-    func getIsSwitzerlandOnly(hcert: DCCCert) -> Result<Bool, CertLogicValidationError> {
-        guard let dccJson = try? JSONEncoder().encode(hcert) else {
-            return .failure(.JSON_ERROR)
-        }
-
-        let context = JSON(["payload": JSON(dccJson)])
-
         var isSwitzerlandOnly: Bool?
 
         for displayRule in displayRules {
-            // get isSwitzerlandOnly
-            if displayRule["id"] == "is-only-valid-in-ch" {
-                guard let result: Bool = try? applyRule(displayRule["logic"], to: context) else {
-                    return .failure(.TEST_COULD_NOT_BE_PERFORMED(test: displayRule["id"].string ?? "CH_ONLY_TEST"))
+            switch displayRule["id"] {
+            case "display-from-date":
+                // get from date
+                if let result: Date = try? applyRule(displayRule["logic"], to: context) {
+                    startDate = result
                 }
 
-                isSwitzerlandOnly = result
+            case "display-until-date":
+                // get end date
+                if let result: Date = try? applyRule(displayRule["logic"], to: context) {
+                    endDate = result
+                }
+
+            case "is-only-valid-in-ch":
+                // get isSwitzerland
+                if let result: Bool = try? applyRule(displayRule["logic"], to: context) {
+                    isSwitzerlandOnly = result
+                }
+
+            default:
+                break
             }
         }
 
-        guard let isSwitzerlandOnly = isSwitzerlandOnly else {
-            return .failure(.TEST_COULD_NOT_BE_PERFORMED(test: "CH_ONLY_TEST"))
-        }
-
-        return .success(isSwitzerlandOnly)
+        return .success(DisplayRulesResult(validFrom: startDate,
+                                           validUntil: endDate,
+                                           isSwitzerlandOnly: isSwitzerlandOnly))
     }
 
     private func externalJson(validationClock: Date) -> JSON {

--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -249,7 +249,7 @@ struct CovidCertificateImpl {
             }
 
             let displayRulesResult = try? certLogic.checkDisplayRules(hcert: certificate).get()
-            
+
             switch certLogic.checkRules(hcert: certificate) {
             case .success:
                 completionHandler(.success(VerificationResult(isValid: true,

--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -248,29 +248,17 @@ struct CovidCertificateImpl {
                 return
             }
 
+            let displayRulesResult = try? certLogic.checkDisplayRules(hcert: certificate).get()
+            
             switch certLogic.checkRules(hcert: certificate) {
             case .success:
-                switch certLogic.checkDisplayRules(hcert: certificate) {
-                case let .success(result):
-                    completionHandler(.success(VerificationResult(isValid: true,
-                                                                  validUntil: result.validUntil,
-                                                                  validFrom: result.validFrom,
-                                                                  dateError: nil,
-                                                                  isSwitzerlandOnly: result.isSwitzerlandOnly)))
-                case .failure:
-                    completionHandler(.success(VerificationResult(isValid: true,
-                                                                  validUntil: nil,
-                                                                  validFrom: nil,
-                                                                  dateError: nil,
-                                                                  isSwitzerlandOnly: nil)))
-                }
+                completionHandler(.success(VerificationResult(isValid: true,
+                                                              validUntil: displayRulesResult?.validUntil,
+                                                              validFrom: displayRulesResult?.validFrom,
+                                                              dateError: nil,
+                                                              isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 return
             case let .failure(.TESTS_FAILED(tests)):
-                var displayRulesResult: DisplayRulesResult?
-                if case let .success(result) = certLogic.checkDisplayRules(hcert: certificate) {
-                    displayRulesResult = result
-                }
-
                 switch tests.keys.first {
                 case "GR-CH-0001": completionHandler(.failure(.WRONG_DISEASE_TARGET))
                 case "VR-CH-0000": completionHandler(.failure(.TOO_MANY_VACCINE_ENTRIES))

--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -250,27 +250,25 @@ struct CovidCertificateImpl {
 
             switch certLogic.checkRules(hcert: certificate) {
             case .success:
-                guard case let .success(validity) = certLogic.getValidity(hcert: certificate),
-                      case let .success(isSwitzerlandOnly) = certLogic.getIsSwitzerlandOnly(hcert: certificate) else {
-                    completionHandler(.failure(.UNKNOWN_TEST_FAILURE))
-                    return
+                switch certLogic.checkDisplayRules(hcert: certificate) {
+                case let .success(result):
+                    completionHandler(.success(VerificationResult(isValid: true,
+                                                                  validUntil: result.validUntil,
+                                                                  validFrom: result.validFrom,
+                                                                  dateError: nil,
+                                                                  isSwitzerlandOnly: result.isSwitzerlandOnly)))
+                case .failure:
+                    completionHandler(.success(VerificationResult(isValid: true,
+                                                                  validUntil: nil,
+                                                                  validFrom: nil,
+                                                                  dateError: nil,
+                                                                  isSwitzerlandOnly: nil)))
                 }
-
-                completionHandler(.success(VerificationResult(isValid: true,
-                                                              validUntil: validity.until,
-                                                              validFrom: validity.from,
-                                                              dateError: nil,
-                                                              isSwitzerlandOnly: isSwitzerlandOnly)))
                 return
             case let .failure(.TESTS_FAILED(tests)):
-                var validity: Validity?
-                if case let .success(sucessValidity) = certLogic.getValidity(hcert: certificate) {
-                    validity = sucessValidity
-                }
-
-                var isSwitzerlandOnly: Bool?
-                if case let .success(chOnly) = certLogic.getIsSwitzerlandOnly(hcert: certificate) {
-                    isSwitzerlandOnly = chOnly
+                var displayRulesResult: DisplayRulesResult?
+                if case let .success(result) = certLogic.checkDisplayRules(hcert: certificate) {
+                    displayRulesResult = result
                 }
 
                 switch tests.keys.first {
@@ -281,34 +279,34 @@ struct CovidCertificateImpl {
                 case "VR-CH-0003": completionHandler(.failure(.NO_VALID_DATE))
                 case "VR-CH-0004":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .NOT_YET_VALID,
-                                                                 isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "VR-CH-0005":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .NOT_YET_VALID,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "VR-CH-0006":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .EXPIRED,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "VR-CH-0007":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .EXPIRED,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "VR-CH-0008":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .EXPIRED,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "TR-CH-0000": completionHandler(.failure(.TOO_MANY_TEST_ENTRIES))
                 case "TR-CH-0001": completionHandler(.failure(.POSITIVE_RESULT))
                 case "TR-CH-0002": completionHandler(.failure(.WRONG_TEST_TYPE))
@@ -316,44 +314,44 @@ struct CovidCertificateImpl {
                 case "TR-CH-0004": completionHandler(.failure(.NO_VALID_DATE))
                 case "TR-CH-0005":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .NOT_YET_VALID,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "TR-CH-0006":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .EXPIRED,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "TR-CH-0007":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .EXPIRED,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "TR-CH-0008":
                     completionHandler(.failure(.NEGATIVE_RESULT))
                 case "TR-CH-0009":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .EXPIRED,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "RR-CH-0000": completionHandler(.failure(.TOO_MANY_RECOVERY_ENTRIES))
                 case "RR-CH-0001": completionHandler(.failure(.NO_VALID_DATE))
                 case "RR-CH-0002":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .NOT_YET_VALID,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 case "RR-CH-0003":
                     completionHandler(.success(VerificationResult(isValid: false,
-                                                                  validUntil: validity?.until,
-                                                                  validFrom: validity?.from,
+                                                                  validUntil: displayRulesResult?.validUntil,
+                                                                  validFrom: displayRulesResult?.validFrom,
                                                                   dateError: .EXPIRED,
-                                                                  isSwitzerlandOnly: isSwitzerlandOnly)))
+                                                                  isSwitzerlandOnly: displayRulesResult?.isSwitzerlandOnly)))
                 default:
                     completionHandler(.failure(.UNKNOWN_TEST_FAILURE))
                 }

--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -42,7 +42,11 @@ public enum CovidCertificateSDK {
                 case let .success(nationalRulesResult):
                     return completionHandler(CheckResults(signature: result.signature,
                                                           revocationStatus: result.revocationStatus,
-                                                          nationalRules: .success(.init(isValid: nationalRulesResult.isValid, validUntil: nil, validFrom: nil, dateError: nil))))
+                                                          nationalRules: .success(.init(isValid: nationalRulesResult.isValid,
+                                                                                        validUntil: nil,
+                                                                                        validFrom: nil,
+                                                                                        dateError: nil,
+                                                                                        isSwitzerlandOnly: nil))))
                 // expose networking errors for verification apps
                 case .failure(.NETWORK_NO_INTERNET_CONNECTION),
                      .failure(.NETWORK_PARSE_ERROR),

--- a/Sources/CovidCertificateSDK/Models/CovidCertificate.swift
+++ b/Sources/CovidCertificateSDK/Models/CovidCertificate.swift
@@ -15,10 +15,6 @@ public protocol CovidCertificate {
     var dateOfBirth: String { get }
     var version: String { get }
     var type: CertificateType { get }
-
-    /// Whether a certificate is a case only valid in Switzerland.
-    /// At the moment, this is true for light certificates and serological tests, false otherwise.
-    var isSwitzerlandOnly: Bool { get }
 }
 
 public extension CovidCertificate {

--- a/Sources/CovidCertificateSDK/Models/LightCert.swift
+++ b/Sources/CovidCertificateSDK/Models/LightCert.swift
@@ -31,8 +31,4 @@ public struct LightCert: CovidCertificate, Codable {
         version = try container.decode(String.self, forKey: .version)
         dateOfBirth = try container.decode(String.self, forKey: .dateOfBirth)
     }
-
-    public var isSwitzerlandOnly: Bool {
-        true
-    }
 }

--- a/Sources/CovidCertificateSDK/Models/VerificationResult.swift
+++ b/Sources/CovidCertificateSDK/Models/VerificationResult.swift
@@ -15,4 +15,5 @@ public struct VerificationResult {
     public let validUntil: Date?
     public let validFrom: Date?
     public let dateError: NationalRulesDateError?
+    public let isSwitzerlandOnly: Bool?
 }

--- a/Sources/CovidCertificateSDK/ehn/Extensions.swift
+++ b/Sources/CovidCertificateSDK/ehn/Extensions.swift
@@ -71,12 +71,4 @@ extension DCCCert {
             return []
         }
     }
-
-    public var isSwitzerlandOnly: Bool {
-        if immunisationType == .test, let t = tests?.first {
-            return t.isSerologicalTest
-        }
-
-        return false
-    }
 }


### PR DESCRIPTION
In the last release, a flag called `isSwitzerlandOnly` was introduced to expose whether a specific certificate was only valid in Switzerland. This flag can be used to display additional information to the user in the wallet app. The rules of whether to show this flag were hardcoded in the SDK, so far returning true for light certificates and serological tests.

This PR changes the behaviour so that the `isSwitzerlandOnly` flag is now computed with the display rules, which makes it more flexible since the rules can be updated from the backend.