### PR TITLE
Feature: Improve offline mode vs. time inconsistency

### DIFF
--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -131,12 +131,14 @@ struct CovidCertificateImpl {
         }
 
         trustListManager.trustCertificateUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
-            // If there is a time inconsistency between server and device, this error takes priority even if there's a valid list
-            if case .TIME_INCONSISTENCY = lastError, let e = lastError?.asValidationError() {
+
+            if case .NETWORK_SERVER_ERROR = lastError {
+                // Only continue with cached trust list for NETWORK_SERVER_ERRORS (HTTP status != 200)
+            } else if let e = lastError?.asValidationError() {
                 completionHandler(.failure(e))
                 return
             }
-
+            
             // Safe-guard that we have a recent trust list available at this point
             guard trustListManager.trustStorage.certificateListIsValid() else {
                 if let e = lastError?.asValidationError() {
@@ -181,8 +183,10 @@ struct CovidCertificateImpl {
 
     func checkRevocationStatus(certificate: DCCCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
         trustListManager.revocationListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
-            // If there is a time inconsistency between server and device, this error takes priority even if there's a valid list
-            if case .TIME_INCONSISTENCY = lastError, let e = lastError?.asValidationError() {
+            
+            if case .NETWORK_SERVER_ERROR = lastError {
+                // Only continue with cached trust list for NETWORK_SERVER_ERRORS (HTTP status != 200)
+            } else if let e = lastError?.asValidationError() {
                 completionHandler(.failure(e))
                 return
             }
@@ -219,8 +223,10 @@ struct CovidCertificateImpl {
         }
 
         trustListManager.nationalRulesListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
-            // If there is a time inconsistency between server and device, this error takes priority even if there's a valid list
-            if case .TIME_INCONSISTENCY = lastError, let e = lastError?.asNationalRulesError() {
+            
+            if case .NETWORK_SERVER_ERROR = lastError {
+                // Only continue with cached trust list for NETWORK_SERVER_ERRORS (HTTP status != 200)
+            } else if let e = lastError?.asNationalRulesError() {
                 completionHandler(.failure(e))
                 return
             }

--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -138,7 +138,7 @@ struct CovidCertificateImpl {
                 completionHandler(.failure(e))
                 return
             }
-            
+
             // Safe-guard that we have a recent trust list available at this point
             guard trustListManager.trustStorage.certificateListIsValid() else {
                 if let e = lastError?.asValidationError() {
@@ -183,7 +183,7 @@ struct CovidCertificateImpl {
 
     func checkRevocationStatus(certificate: DCCCert, forceUpdate: Bool, _ completionHandler: @escaping (Result<ValidationResult, ValidationError>) -> Void) {
         trustListManager.revocationListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
-            
+
             if case .NETWORK_SERVER_ERROR = lastError {
                 // Only continue with cached trust list for NETWORK_SERVER_ERRORS (HTTP status != 200)
             } else if let e = lastError?.asValidationError() {
@@ -223,7 +223,7 @@ struct CovidCertificateImpl {
         }
 
         trustListManager.nationalRulesListUpdater.addCheckOperation(forceUpdate: forceUpdate, checkOperation: { lastError in
-            
+
             if case .NETWORK_SERVER_ERROR = lastError {
                 // Only continue with cached trust list for NETWORK_SERVER_ERRORS (HTTP status != 200)
             } else if let e = lastError?.asNationalRulesError() {

--- a/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
+++ b/Sources/CovidCertificateSDK/NationalRules/NationalRulesError.swift
@@ -21,6 +21,7 @@ public enum NationalRulesError: Error, Equatable {
     case NO_VALID_DATE
     case NETWORK_ERROR(errorCode: String)
     case NETWORK_PARSE_ERROR
+    case NETWORK_SERVER_ERROR(statusCode: Int)
     case NETWORK_NO_INTERNET_CONNECTION(errorCode: String)
     case TIME_INCONSISTENCY(timeShift: TimeInterval)
     case UNKNOWN_CERTLOGIC_FAILURE
@@ -39,6 +40,7 @@ public enum NationalRulesError: Error, Equatable {
         case .NO_VALID_DATE: return "N|NVD"
         case let .NETWORK_ERROR(code): return code.count > 0 ? "NE|\(code)" : "NE"
         case .NETWORK_PARSE_ERROR: return "NE|PE"
+        case let .NETWORK_SERVER_ERROR(statusCode): return "NE|SE-\(statusCode)"
         case let .NETWORK_NO_INTERNET_CONNECTION(code): return code.count > 0 ? "NE|\(code)" : "NE|NIC"
         case .TIME_INCONSISTENCY: return "NE|TI"
         case .UNKNOWN_CERTLOGIC_FAILURE: return "N|UKN"

--- a/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NationalRulesListUpdate.swift
@@ -31,7 +31,7 @@ class NationalRulesListUpdate: TrustListUpdate {
               let httpResponse = response as? HTTPURLResponse else {
             return .NETWORK_PARSE_ERROR
         }
-        
+
         // Make sure HTTP response code is 2xx
         guard httpResponse.statusCode / 100 == 2 else {
             return .NETWORK_SERVER_ERROR(statusCode: httpResponse.statusCode)

--- a/Sources/CovidCertificateSDK/TrustList/NetworkError.swift
+++ b/Sources/CovidCertificateSDK/TrustList/NetworkError.swift
@@ -14,6 +14,7 @@ import Foundation
 public enum NetworkError: Error, Equatable {
     case NETWORK_ERROR(errorCode: String)
     case NETWORK_PARSE_ERROR
+    case NETWORK_SERVER_ERROR(statusCode: Int)
     case NETWORK_NO_INTERNET_CONNECTION(errorCode: String)
     case TIME_INCONSISTENCY(timeShift: TimeInterval)
 
@@ -23,6 +24,8 @@ public enum NetworkError: Error, Equatable {
             return "A network error occured"
         case .NETWORK_PARSE_ERROR:
             return "The data could not be parsed"
+        case .NETWORK_SERVER_ERROR:
+            return "The server returned an unexpected HTTP status code"
         case .NETWORK_NO_INTERNET_CONNECTION:
             return "The internet connection appears to be offline"
         case .TIME_INCONSISTENCY:
@@ -34,6 +37,7 @@ public enum NetworkError: Error, Equatable {
         switch self {
         case let .NETWORK_ERROR(code): return code.count > 0 ? "NE|\(code)" : "NE"
         case .NETWORK_PARSE_ERROR: return "NE|PE"
+        case let .NETWORK_SERVER_ERROR(statusCode): return "NE|SE-\(statusCode)"
         case let .NETWORK_NO_INTERNET_CONNECTION(code): return code.count > 0 ? "NE|\(code)" : "NE|NIC"
         case .TIME_INCONSISTENCY: return "NE|TI"
         }
@@ -67,6 +71,8 @@ extension NetworkError {
             return .NETWORK_ERROR(errorCode: errorCode)
         case .NETWORK_PARSE_ERROR:
             return .NETWORK_PARSE_ERROR
+        case let .NETWORK_SERVER_ERROR(statusCode):
+            return .NETWORK_SERVER_ERROR(statusCode: statusCode)
         case let .NETWORK_NO_INTERNET_CONNECTION(errorCode):
             return .NETWORK_NO_INTERNET_CONNECTION(errorCode: errorCode)
         case let .TIME_INCONSISTENCY(timeShift):
@@ -82,6 +88,8 @@ extension NetworkError {
             return .NETWORK_ERROR(errorCode: errorCode)
         case .NETWORK_PARSE_ERROR:
             return .NETWORK_PARSE_ERROR
+        case let .NETWORK_SERVER_ERROR(statusCode):
+            return .NETWORK_SERVER_ERROR(statusCode: statusCode)
         case let .NETWORK_NO_INTERNET_CONNECTION(errorCode):
             return .NETWORK_NO_INTERNET_CONNECTION(errorCode: errorCode)
         case let .TIME_INCONSISTENCY(timeShift):

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -54,7 +54,7 @@ class RevocationListUpdate: TrustListUpdate {
                   let httpResponse = response as? HTTPURLResponse else {
                 return .NETWORK_PARSE_ERROR
             }
-            
+
             // Make sure HTTP response code is 2xx
             guard httpResponse.statusCode / 100 == 2 else {
                 return .NETWORK_SERVER_ERROR(statusCode: httpResponse.statusCode)

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -54,6 +54,11 @@ class RevocationListUpdate: TrustListUpdate {
                   let httpResponse = response as? HTTPURLResponse else {
                 return .NETWORK_PARSE_ERROR
             }
+            
+            // Make sure HTTP response code is 2xx
+            guard httpResponse.statusCode / 100 == 2 else {
+                return .NETWORK_SERVER_ERROR(statusCode: httpResponse.statusCode)
+            }
 
             // get the `x-next-since` from HTTP headers, save it and pass to the next request
             guard let nextSinceHeader = httpResponse.value(forHeaderField: "x-next-since") else {

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -35,6 +35,11 @@ class TrustCertificatesUpdate: TrustListUpdate {
               let httpResponse = response as? HTTPURLResponse else {
             return .NETWORK_PARSE_ERROR
         }
+        
+        // Make sure HTTP response code is 2xx
+        guard httpResponse.statusCode / 100 == 2 else {
+            return .NETWORK_SERVER_ERROR(statusCode: httpResponse.statusCode)
+        }
 
         let semaphore = DispatchSemaphore(value: 0)
         var outcome: Result<ActiveTrustCertificates, JWSError> = .failure(.SIGNATURE_INVALID)

--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -35,7 +35,7 @@ class TrustCertificatesUpdate: TrustListUpdate {
               let httpResponse = response as? HTTPURLResponse else {
             return .NETWORK_PARSE_ERROR
         }
-        
+
         // Make sure HTTP response code is 2xx
         guard httpResponse.statusCode / 100 == 2 else {
             return .NETWORK_SERVER_ERROR(statusCode: httpResponse.statusCode)

--- a/Sources/CovidCertificateSDK/ehn/ValidationError.swift
+++ b/Sources/CovidCertificateSDK/ehn/ValidationError.swift
@@ -43,6 +43,7 @@ public enum ValidationError: Error, Equatable {
     case SIGNATURE_TYPE_INVALID(SignatureTypeInvalidError)
     case NETWORK_ERROR(errorCode: String)
     case NETWORK_PARSE_ERROR
+    case NETWORK_SERVER_ERROR(statusCode: Int)
     case NETWORK_NO_INTERNET_CONNECTION(errorCode: String)
     case TIME_INCONSISTENCY(timeShift: TimeInterval)
 
@@ -64,6 +65,7 @@ public enum ValidationError: Error, Equatable {
         case .SIGNATURE_TYPE_INVALID: return "The certificate is not valid according to specification"
         case .NETWORK_ERROR: return "A network error occured"
         case .NETWORK_PARSE_ERROR: return "The data could not be parsed"
+        case .NETWORK_SERVER_ERROR: return "The server returned an unexpected HTTP status code"
         case .NETWORK_NO_INTERNET_CONNECTION: return "The internet connection appears to be offline"
         case .TIME_INCONSISTENCY: return "There seems to be a time inconsistency"
         }
@@ -87,6 +89,7 @@ public enum ValidationError: Error, Equatable {
         case let .SIGNATURE_TYPE_INVALID(wrapped): return "S|TIV|" + wrapped.errorCode
         case let .NETWORK_ERROR(code): return code.count > 0 ? "NE|\(code)" : "NE"
         case .NETWORK_PARSE_ERROR: return "NE|PE"
+        case let .NETWORK_SERVER_ERROR(statusCode): return "NE|SE-\(statusCode)"
         case let .NETWORK_NO_INTERNET_CONNECTION(code): return code.count > 0 ? "NE|\(code)" : "NE|NIC"
         case .TIME_INCONSISTENCY: return "NE|TI"
         }


### PR DESCRIPTION
This pull-request changes the network error handling. Assuming that AWS infrastructure is nearly always available, we will get an HTTP error (status code != 2xx) if BIT infrastructure is not available. With this change, force-refresh will only use cached data if BIT's infrastructure is not available but fail for other network errors (e.g. Airplane mode,...).