### PR TITLE
Separated mode check errors

### DIFF
--- a/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateImpl.swift
@@ -270,7 +270,7 @@ struct CovidCertificateImpl {
             }
 
             for (mode, modeResult) in certLogic.checkModeRules(holder: holder, modes: modes) {
-                switch modeResult{
+                switch modeResult {
                 case let .success(modeResult):
                     modeResults[mode] = .success(modeResult)
                 case .failure(.TEST_COULD_NOT_BE_PERFORMED(_)):
@@ -280,7 +280,6 @@ struct CovidCertificateImpl {
                 }
             }
             result.modeResults = .init(results: modeResults)
-
 
             guard let certificate = holder.certificate as? DCCCert else {
                 // a light certificate is not valid if the CWT has expired

--- a/Sources/CovidCertificateSDK/Models/CheckResults.swift
+++ b/Sources/CovidCertificateSDK/Models/CheckResults.swift
@@ -14,13 +14,13 @@ public struct CheckResults {
     public let signature: Result<ValidationResult, ValidationError>
     public let revocationStatus: Result<ValidationResult, ValidationError>?
     public let nationalRules: Result<VerificationResult, NationalRulesError>
-    public let modeResults: Result<ModeResults, NationalRulesError>
+    public let modeResults: ModeResults
 }
 
 public struct ModeResults: Equatable {
-    public let results: [CheckMode: ModeCheckResult]
+    public let results: [CheckMode: Result<ModeCheckResult, NationalRulesError>]
 
-    public func getResult(for mode: CheckMode) -> ModeCheckResult? {
+    public func getResult(for mode: CheckMode) -> Result<ModeCheckResult, NationalRulesError>? {
         results.keys.contains(mode) ? results[mode] : nil
     }
 }

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -1009,10 +1009,10 @@ final class CovidCertificateSDKTests: XCTestCase {
 
         let expectation = expectation(description: "fail")
         verifier.checkNationalRules(holder: TestCertificateHolder(cert: hcert), forceUpdate: false, modes: .twoG) { result in
-            switch result.modeResults {
+            switch result.modeResults.getResult(for: .twoG) {
             case let .success(r):
                 /// TEST IS NOT VALID IN 2G MODE
-                XCTAssertFalse(r.getResult(for: .twoG)!.isValid)
+                XCTAssertFalse(r.isValid)
             default:
                 XCTFail("Something happened")
             }
@@ -1030,10 +1030,10 @@ final class CovidCertificateSDKTests: XCTestCase {
 
         let expectation = expectation(description: "fail")
         verifier.checkNationalRules(holder: TestCertificateHolder(cert: hcert), forceUpdate: false, modes: .threeG) { result in
-            switch result.modeResults {
+            switch result.modeResults.getResult(for: .threeG) {
             case let .success(r):
                 /// TEST IS VALID IN 2G MODE
-                XCTAssertTrue(r.getResult(for: .threeG)!.isValid)
+                XCTAssertTrue(r.isValid)
             default:
                 XCTFail("Something happened")
             }
@@ -1047,9 +1047,9 @@ final class CovidCertificateSDKTests: XCTestCase {
 
         let twoGExpecation = expectation(description: "success")
         verifier.checkNationalRules(holder: TestCertificateHolder(cert: hcert), forceUpdate: false, modes: .twoG) { result in
-            switch result.modeResults {
+            switch result.modeResults.getResult(for: .twoG) {
             case let .success(r):
-                XCTAssertTrue(r.getResult(for: .twoG)!.isValid)
+                XCTAssertTrue(r.isValid)
             default:
                 XCTFail("Something happened")
             }
@@ -1058,9 +1058,9 @@ final class CovidCertificateSDKTests: XCTestCase {
 
         let threeGExpecation = expectation(description: "success")
         verifier.checkNationalRules(holder: TestCertificateHolder(cert: hcert), forceUpdate: false, modes: .threeG) { result in
-            switch result.modeResults {
+            switch result.modeResults.getResult(for: .threeG) {
             case let .success(r):
-                XCTAssertTrue(r.getResult(for: .threeG)!.isValid)
+                XCTAssertTrue(r.isValid)
             default:
                 XCTFail("Something happened")
             }


### PR DESCRIPTION
Do not fail all mode checks if one check fails, therefore we now return all checks individually.