### PR TITLE
Add missing http response code check to trust list updates

### DIFF
--- a/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustCertificatesUpdate.swift
@@ -90,6 +90,11 @@ class TrustCertificatesUpdate: TrustListUpdate {
                 return .NETWORK_PARSE_ERROR
             }
 
+            // Make sure HTTP response code is 2xx
+            guard httpResponse.statusCode / 100 == 2 else {
+                return .NETWORK_SERVER_ERROR(statusCode: httpResponse.statusCode)
+            }
+
             // get the `x-next-since` from HTTP headers, save it and pass to the next request
             guard let nextSinceHeader = httpResponse.value(forHeaderField: "x-next-since") else {
                 return .NETWORK_PARSE_ERROR


### PR DESCRIPTION
This PR adds a missing != 2xx check to all trust list update requests