### PR TITLE
Pre-packaged revocation list

### DIFF
--- a/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
+++ b/Sources/CovidCertificateSDK/CovidCertificateSDK.swift
@@ -23,6 +23,10 @@ public enum CovidCertificateSDK {
         instance.updateMetadata()
     }
 
+    public static var isInitialized: Bool {
+        instance != nil
+    }
+
     public enum Verifier {
         public static func decode(encodedData: String) -> Result<VerifierCertificateHolder, CovidCertError> {
             instancePrecondition()

--- a/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationListUpdate.swift
@@ -16,8 +16,6 @@ class RevocationListUpdate: TrustListUpdate {
 
     let session = URLSession.certificatePinned
 
-    @UBUserDefault(key: "covidcertififcate.revocations.nextSince", defaultValue: nil)
-    var nextSince: String?
 
     private static let falseConstant = "false"
 
@@ -35,7 +33,7 @@ class RevocationListUpdate: TrustListUpdate {
             requestsCount = requestsCount + 1
 
             // download data and update local storage
-            let request = CovidCertificateSDK.currentEnvironment.revocationListService(since: nextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
+            let request = CovidCertificateSDK.currentEnvironment.revocationListService(since: trustStorage.revocationListNextSince).request(reloadIgnoringLocalCache: ignoreLocalCache)
             let (data, response, error) = session.synchronousDataTask(with: request)
 
             // Only run timeshift detection if request does not come from cache
@@ -84,9 +82,8 @@ class RevocationListUpdate: TrustListUpdate {
                 return .NETWORK_PARSE_ERROR
             }
 
-            _ = trustStorage.updateRevocationList(result)
-
-            nextSince = nextSinceHeader
+            let success = trustStorage.updateRevocationList(result, nextSince: nextSinceHeader)
+            assert(success)
 
             // start another request, as long as revocations are coming in
             listNeedsUpdate = upToDate == Self.falseConstant

--- a/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustStorage.swift
@@ -37,7 +37,7 @@ class TrustStorage: TrustStorageProtocol {
     private lazy var activeCertificatesStorage = self.activeCertificatesSecureStorage.loadSynchronously() ?? ActiveCertificatesStorage()
     private let activeCertificatesSecureStorage = SecureStorage<ActiveCertificatesStorage>(name: "active_certificates")
 
-    private lazy var revocationStorage = self.revocationSecureStorage.loadSynchronously() ?? RevocationStorage.bundledStorage
+    private lazy var revocationStorage = self.revocationSecureStorage.loadSynchronously() ?? RevocationStorage.getBundledStorage()
     private let revocationSecureStorage = SecureStorage<RevocationStorage>(name: "revocations")
 
     let revocationQueue = DispatchQueue(label: "storage.sync.revocation")
@@ -190,9 +190,9 @@ class NationalRulesStorage: Codable {
 }
 
 extension RevocationStorage {
-    static var bundledStorage: RevocationStorage {
+    static func getBundledStorage(environment: SDKEnvironment = CovidCertificateSDK.currentEnvironment) -> RevocationStorage {
         // only the prod revocations are pre-packaged
-        guard CovidCertificateSDK.currentEnvironment == .prod,
+        guard environment == .prod,
               let resource = Bundle.module.path(forResource: "revocations", ofType: "json"),
               let data = try? Data(contentsOf: URL(fileURLWithPath: resource), options: .mappedIfSafe),
               let bundled = try? JSONDecoder().decode(RevocationStorage.self, from: data)

--- a/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
+++ b/Tests/CovidCertificateSDKTests/CovidCertificateSDKTests.swift
@@ -31,7 +31,9 @@ final class CovidCertificateSDKTests: XCTestCase {
     // MARK: - Setup
 
     override class func setUp() {
-        CovidCertificateSDK.initialize(environment: SDKEnvironment.dev, apiKey: "")
+        if !CovidCertificateSDK.isInitialized {
+            CovidCertificateSDK.initialize(environment: .dev, apiKey: "")
+        }
     }
 
     // MARK: - Helpers

--- a/Tests/CovidCertificateSDKTests/MockNetworking.swift
+++ b/Tests/CovidCertificateSDKTests/MockNetworking.swift
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import Foundation
+
+class MockTask: URLSessionDataTask {
+    private let data_: Data?
+    private let urlResponse_: URLResponse?
+    private let error_: Error?
+
+    var internalState: URLSessionTask.State = .suspended
+
+    override var state: URLSessionTask.State {
+        internalState
+    }
+
+    override func cancel() {
+        internalState = .canceling
+    }
+
+    var completionHandler: ((Data?, URLResponse?, Error?) -> Void)?
+
+    init(data: Data?, urlResponse: URLResponse?, error: Error?) {
+        data_ = data
+        urlResponse_ = urlResponse
+        error_ = error
+    }
+
+    override func resume() {
+        internalState = .running
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            guard let self = self else { return }
+            if self.internalState != .canceling {
+                self.internalState = .completed
+                self.completionHandler?(self.data_, self.urlResponse_, self.error_)
+            }
+        }
+    }
+}
+
+class MockUrlCache: URLCache {
+    var response: CachedURLResponse?
+    init(response: CachedURLResponse) {
+        self.response = response
+        super.init(memoryCapacity: 1, diskCapacity: 1, diskPath: "")
+    }
+
+    override func cachedResponse(for _: URLRequest) -> CachedURLResponse? {
+        return response
+    }
+}
+
+class MockSession: URLSession {
+    let handler: ((URLRequest) -> (Data?, URLResponse?, Error?))
+    var requests: [URLRequest] = []
+
+    init(handler: @escaping ((URLRequest) -> (Data?, URLResponse?, Error?))) {
+        self.handler = handler
+    }
+
+    override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
+        requests.append(request)
+        let (data, urlResponse, error) = handler(request)
+        let task = MockTask(data: data, urlResponse: urlResponse, error: error)
+        task.completionHandler = completionHandler
+        return task
+    }
+}

--- a/Tests/CovidCertificateSDKTests/MockNetworking.swift
+++ b/Tests/CovidCertificateSDKTests/MockNetworking.swift
@@ -53,12 +53,12 @@ class MockUrlCache: URLCache {
     }
 
     override func cachedResponse(for _: URLRequest) -> CachedURLResponse? {
-        return response
+        response
     }
 }
 
 class MockSession: URLSession {
-    let handler: ((URLRequest) -> (Data?, URLResponse?, Error?))
+    let handler: (URLRequest) -> (Data?, URLResponse?, Error?)
     var requests: [URLRequest] = []
 
     init(handler: @escaping ((URLRequest) -> (Data?, URLResponse?, Error?))) {

--- a/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
+++ b/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
@@ -17,28 +17,29 @@ final class RevocationListUpdateTests: XCTestCase {
             CovidCertificateSDK.initialize(environment: .dev, apiKey: "")
         }
     }
+
     func testUpdate() {
         let storage = TestTrustStorage(publicKeys: [])
         storage.revokedCerts.insert("a")
         storage.revokedCerts.insert("b")
         storage.revokedCerts.insert("c")
-        var lastNextSince: String? = nil
-        let revs = (0...100_000).map(String.init)
+        var lastNextSince: String?
+        let revs = (0 ... 100_000).map(String.init)
         let session = MockSession { request in
-            URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach({ item in
+            URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach { item in
                 if item.name == "since" {
                     XCTAssertEqual(item.value, lastNextSince)
                 }
-            })
+            }
 
             let since: Int = lastNextSince == nil ? 0 : Int(lastNextSince!)!
-            let nextSince = min(since + 5_000, revs.count)
+            let nextSince = min(since + 5000, revs.count)
             let list = RevocationList()
-            list.revokedCerts = Set<String>(revs[since...nextSince])
+            list.revokedCerts = Set<String>(revs[since ... nextSince])
             let data = try! JSONEncoder().encode(list)
             let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
-                "up-to-date": nextSince == revs.count ? "true": "false",
-                "x-next-since": String(nextSince)
+                "up-to-date": nextSince == revs.count ? "true" : "false",
+                "x-next-since": String(nextSince),
             ])
             lastNextSince = String(nextSince)
             return (data, httpResponse, nil)
@@ -53,9 +54,9 @@ final class RevocationListUpdateTests: XCTestCase {
     func testPrePackagedDecoding() {
         let storage = RevocationStorage.getBundledStorage(environment: .prod)
         XCTAssertEqual(storage.nextSince, "11743455")
-        XCTAssertEqual(storage.lastRevocationListDownload, 1641452551535)
-        XCTAssertEqual(storage.revocationList.validDuration, 172800000)
-        XCTAssertEqual(storage.revocationList.revokedCerts.count, 353501)
+        XCTAssertEqual(storage.lastRevocationListDownload, 1_641_452_551_535)
+        XCTAssertEqual(storage.revocationList.validDuration, 172_800_000)
+        XCTAssertEqual(storage.revocationList.revokedCerts.count, 353_501)
     }
 }
 

--- a/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
+++ b/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Ubique Innovation AG <https://www.ubique.ch>
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+@testable import CovidCertificateSDK
+import XCTest
+
+final class RevocationListUpdateTests: XCTestCase {
+    override func setUp() {
+        if !CovidCertificateSDK.isInitialized {
+            CovidCertificateSDK.initialize(environment: .dev, apiKey: "")
+        }
+    }
+    func testUpdate() {
+        let storage = TestTrustStorage(publicKeys: [])
+        storage.revokedCerts.insert("a")
+        storage.revokedCerts.insert("b")
+        storage.revokedCerts.insert("c")
+        var lastNextSince: String? = nil
+        let revs = (0...100_000).map(String.init)
+        let session = MockSession { request in
+            URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach({ item in
+                if item.name == "since" {
+                    XCTAssertEqual(item.value, lastNextSince)
+                }
+            })
+
+            let since: Int = lastNextSince == nil ? 0 : Int(lastNextSince!)!
+            let nextSince = min(since + 5_000, revs.count)
+            let list = RevocationList()
+            list.revokedCerts = Set<String>(revs[since...nextSince])
+            let data = try! JSONEncoder().encode(list)
+            let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
+                "up-to-date": nextSince == revs.count ? "true": "false",
+                "x-next-since": String(nextSince)
+            ])
+            lastNextSince = String(nextSince)
+            return (data, httpResponse, nil)
+        }
+        let update = RevocationListUpdate(trustStorage: storage, decoder: RevocationListJSONDecoder(), session: session)
+        _ = update.synchronousUpdate()
+        XCTAssertEqual(storage.nextSince, "100000")
+        XCTAssertEqual(storage.revokedCertificates(), Set<String>(revs + ["a", "b", "c"]))
+        XCTAssertEqual(session.requests.count, 20)
+    }
+}
+
+class RevocationListJSONDecoder: RevocationListDecoder {
+    func decode(_ data: Data) -> RevocationList? {
+        try? JSONDecoder().decode(RevocationList.self, from: data)
+    }
+}

--- a/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
+++ b/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
@@ -49,6 +49,14 @@ final class RevocationListUpdateTests: XCTestCase {
         XCTAssertEqual(storage.revokedCertificates(), Set<String>(revs + ["a", "b", "c"]))
         XCTAssertEqual(session.requests.count, 20)
     }
+
+    func testPrePackagedDecoding() {
+        let storage = RevocationStorage.getBundledStorage(environment: .prod)
+        XCTAssertEqual(storage.nextSince, "11743455")
+        XCTAssertEqual(storage.lastRevocationListDownload, 1641452551535)
+        XCTAssertEqual(storage.revocationList.validDuration, 172800000)
+        XCTAssertEqual(storage.revocationList.revokedCerts.count, 353501)
+    }
 }
 
 class RevocationListJSONDecoder: RevocationListDecoder {

--- a/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
+++ b/Tests/CovidCertificateSDKTests/TestTrustListManager.swift
@@ -71,6 +71,8 @@ class TestTrustListUpdate: TrustListUpdate {
 
 class TestTrustStorage: TrustStorageProtocol {
     private let publicKeys: [TrustListPublicKey]
+    public var revokedCerts: Set<String> = []
+    public var nextSince: String?
 
     init(publicKeys: [TrustListPublicKey]) {
         self.publicKeys = publicKeys
@@ -79,16 +81,21 @@ class TestTrustStorage: TrustStorageProtocol {
     // MARK: - Revocation list
 
     func revokedCertificates() -> Set<String> {
-        []
+        revokedCerts
     }
 
-    func updateRevocationList(_: RevocationList) -> Bool {
-        // do nothing
-        true
+    func updateRevocationList(_ list: RevocationList, nextSince: String) -> Bool {
+        list.revokedCerts.forEach { revokedCerts.insert($0) }
+        self.nextSince = nextSince
+        return true
     }
 
     func revocationListIsValid() -> Bool {
         true
+    }
+
+    var revocationListNextSince: String? {
+        nextSince
     }
 
     // MARK: - Active Certificates


### PR DESCRIPTION
- store next since along with revocation list (this fixes a potential deviation between next since and the actual revocation list)
- pre-package the current revocation list
- adds unit tests for the revocation list update logic