### PR TITLE
Only use last 32 bytes for EC key

### DIFF
--- a/Sources/CovidCertificateSDK/TrustList/TrustListPublicKey.swift
+++ b/Sources/CovidCertificateSDK/TrustList/TrustListPublicKey.swift
@@ -42,8 +42,8 @@ class TrustListPublicKey {
                                            kSecAttrKeyType: kSecAttrKeyTypeEC]
 
         guard let x = x, let y = y,
-              let xData = Data(base64Encoded: x),
-              let yData = Data(base64Encoded: y),
+              let xData = Data(base64Encoded: x)?.suffix(32),
+              let yData = Data(base64Encoded: y)?.suffix(32),
               let key = SecKeyCreateWithData(Data([0x4] + xData + yData) as CFData, attributes as CFDictionary, nil) else {
             return nil
         }


### PR DESCRIPTION
We use P256 Uncompressed Point Format as described in [2.3.3 Elliptic-Curve-Point-to-Octet-String Conversion](https://www.secg.org/sec1-v2.pdf) which uses exactly 32 bytes per coordinate.

Since the BigInteger should be interpreted as an unsigned BigInteger, the leading 0 byte, needed if the most significant bit of the corresponding _signed_ BigInteger would be set, can be left out, and only the last 32 bytes are needed.