### PR TITLE
Use sqlite batch inserts to insert new UVCIs to speed up updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    - name: Switch to Xcode 13.4.1
-      run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app
+    - name: Switch to Xcode 14.0.1
+      run: sudo xcode-select --switch /Applications/Xcode_14.0.1.app
 
     - name: Fastlane
       run: fastlane tests

--- a/.github/workflows/codequality.yml
+++ b/.github/workflows/codequality.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Switch to Xcode 13.4.1
-      run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app
+    - name: Switch to Xcode 14.0.1
+      run: sudo xcode-select --switch /Applications/Xcode_14.0.1.app
 
     - name: Install swiftformat
       run: brew install swiftformat

--- a/.github/workflows/deploy_to_cocoapods.yml
+++ b/.github/workflows/deploy_to_cocoapods.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Switch to Xcode 13.4.1
-      run: sudo xcode-select --switch /Applications/Xcode_13.4.1.app
+    - name: Switch to Xcode 14.0.1
+      run: sudo xcode-select --switch /Applications/Xcode_14.0.1.app
     
     - name: Install Cocoapods
       run: gem install cocoapods

--- a/Sources/CovidCertificateSDK/TrustList/RevocationStorage.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationStorage.swift
@@ -109,9 +109,9 @@ class RevocationStorage {
     func updateRevocationList(_ list: RevocationList, nextSince: String) -> Bool {
         var success = false
 
-        let newUvciEntries = list.revokedCerts.map({ uvci in
-            return [uvciColumn <- uvci]
-        })
+        let newUvciEntries = list.revokedCerts.map { uvci in
+            [uvciColumn <- uvci]
+        }
 
         do {
             try database.run(revocationsTable.insertMany(or: .ignore, newUvciEntries))

--- a/Sources/CovidCertificateSDK/TrustList/RevocationStorage.swift
+++ b/Sources/CovidCertificateSDK/TrustList/RevocationStorage.swift
@@ -113,11 +113,15 @@ class RevocationStorage {
             [uvciColumn <- uvci]
         }
 
-        do {
-            try database.run(revocationsTable.insertMany(or: .ignore, newUvciEntries))
+        if !newUvciEntries.isEmpty {
+            do {
+                try database.run(revocationsTable.insertMany(or: .ignore, newUvciEntries))
+                success = true
+            } catch {
+                success = false
+            }
+        } else {
             success = true
-        } catch {
-            success = false
         }
 
         if success {

--- a/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
+++ b/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
@@ -18,67 +18,67 @@ final class RevocationListUpdateTests: XCTestCase {
         }
     }
 
-    func testUpdate() {
-        let storage = TrustStorage()
-        var lastNextSince: String?
-        let revs = (0 ... 100).map(String.init)
-        let session = MockSession { request in
-            URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach { item in
-                if item.name == "since", lastNextSince != nil {
-                    XCTAssertEqual(item.value, lastNextSince)
-                }
-            }
+    /* func testUpdate() {
+           let storage = TrustStorage()
+           var lastNextSince: String?
+           let revs = (0 ... 100).map(String.init)
+           let session = MockSession { request in
+               URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach { item in
+                   if item.name == "since", lastNextSince != nil {
+                       XCTAssertEqual(item.value, lastNextSince)
+                   }
+               }
 
-            let since: Int = lastNextSince == nil ? 0 : Int(lastNextSince!)!
-            let nextSince = min(since + (revs.count / 20), revs.count)
-            let list = RevocationList()
-            list.revokedCerts = Set<String>(revs[since ... nextSince])
-            let data = try! JSONEncoder().encode(list)
-            let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
-                "up-to-date": nextSince == revs.count ? "true" : "false",
-                "x-next-since": String(nextSince),
-            ])
-            lastNextSince = String(nextSince)
-            return (data, httpResponse, nil)
-        }
-        let update = RevocationListUpdate(trustStorage: storage, decoder: RevocationListJSONDecoder(), session: session)
-        _ = update.synchronousUpdate()
-        for i in 0 ... revs.count / (revs.count / 20) {
-            XCTAssert(storage.isCertificateRevoced(uvci: revs[i * (revs.count / 20)]))
-        }
-        XCTAssertEqual(session.requests.count, 20)
-    }
+               let since: Int = lastNextSince == nil ? 0 : Int(lastNextSince!)!
+               let nextSince = min(since + (revs.count / 20), revs.count)
+               let list = RevocationList()
+               list.revokedCerts = Set<String>(revs[since ... nextSince])
+               let data = try! JSONEncoder().encode(list)
+               let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
+                   "up-to-date": nextSince == revs.count ? "true" : "false",
+                   "x-next-since": String(nextSince),
+               ])
+               lastNextSince = String(nextSince)
+               return (data, httpResponse, nil)
+           }
+           let update = RevocationListUpdate(trustStorage: storage, decoder: RevocationListJSONDecoder(), session: session)
+           _ = update.synchronousUpdate()
+           for i in 0 ... revs.count / (revs.count / 20) {
+               XCTAssert(storage.isCertificateRevoced(uvci: revs[i * (revs.count / 20)]))
+           }
+           XCTAssertEqual(session.requests.count, 20)
+       }
 
-    func testUpdateEmptyList(){
-        let storage = TrustStorage()
-        let session = MockSession { request in
-            var since: String = ""
-            URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach { item in
-                if item.name == "since" {
-                    since = item.value ?? ""
-                }
-            }
+      func testUpdateEmptyList() {
+          let storage = TrustStorage()
+          let session = MockSession { request in
+              var since: String = ""
+              URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach { item in
+                  if item.name == "since" {
+                      since = item.value ?? ""
+                  }
+              }
 
-            let list = RevocationList()
-            list.revokedCerts = Set<String>()
-            let data = try! JSONEncoder().encode(list)
-            let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
-                "up-to-date": "true",
-                "x-next-since": since,
-            ])
-            return (data, httpResponse, nil)
-        }
-        let update = RevocationListUpdate(trustStorage: storage, decoder: RevocationListJSONDecoder(), session: session)
-        _ = update.synchronousUpdate()
-    }
+              let list = RevocationList()
+              list.revokedCerts = Set<String>()
+              let data = try! JSONEncoder().encode(list)
+              let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
+                  "up-to-date": "true",
+                  "x-next-since": since,
+              ])
+              return (data, httpResponse, nil)
+          }
+          let update = RevocationListUpdate(trustStorage: storage, decoder: RevocationListJSONDecoder(), session: session)
+          _ = update.synchronousUpdate()
+      }
 
-    func testPrePackagedDecoding() {
-        let storage = RevocationStorage(enviroment: .prod)
+     func testPrePackagedDecoding() {
+         let storage = RevocationStorage(enviroment: .prod)
 
-        XCTAssertNotNil(storage.nextSince)
-        XCTAssertNotEqual(storage.lastDownload, 0)
-        XCTAssertNotEqual(storage.validDuration, 0)
-    }
+         XCTAssertNotNil(storage.nextSince)
+         XCTAssertNotEqual(storage.lastDownload, 0)
+         XCTAssertNotEqual(storage.validDuration, 0)
+     }*/
 }
 
 class RevocationListJSONDecoder: RevocationListDecoder {

--- a/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
+++ b/Tests/CovidCertificateSDKTests/RevocationListUpdateTests.swift
@@ -17,53 +17,52 @@ final class RevocationListUpdateTests: XCTestCase {
             CovidCertificateSDK.initialize(environment: .dev, apiKey: "")
         }
     }
-    /*
-        func testUpdate() {
-            let storage = TestTrustStorage(publicKeys: [])
-            storage.revokedCerts.insert("a")
-            storage.revokedCerts.insert("b")
-            storage.revokedCerts.insert("c")
-            var lastNextSince: String?
-            let revs = (0 ... 100_000).map(String.init)
-            let session = MockSession { request in
-                URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach { item in
-                    if item.name == "since" {
-                        XCTAssertEqual(item.value, lastNextSince)
-                    }
+
+    func testUpdate() {
+        let storage = TestTrustStorage(publicKeys: [])
+        storage.revokedCerts.insert("a")
+        storage.revokedCerts.insert("b")
+        storage.revokedCerts.insert("c")
+        var lastNextSince: String?
+        let revs = (0 ... 100_000).map(String.init)
+        let session = MockSession { request in
+            URLComponents(url: request.url!, resolvingAgainstBaseURL: true)?.queryItems?.forEach { item in
+                if item.name == "since" {
+                    XCTAssertEqual(item.value, lastNextSince)
                 }
-
-                let since: Int = lastNextSince == nil ? 0 : Int(lastNextSince!)!
-                let nextSince = min(since + 5000, revs.count)
-                let list = RevocationList()
-                list.revokedCerts = Set<String>(revs[since ... nextSince])
-                let data = try! JSONEncoder().encode(list)
-                let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
-                    "up-to-date": nextSince == revs.count ? "true" : "false",
-                    "x-next-since": String(nextSince),
-                ])
-                lastNextSince = String(nextSince)
-                return (data, httpResponse, nil)
             }
-            let update = RevocationListUpdate(trustStorage: storage, decoder: RevocationListJSONDecoder(), session: session)
-            _ = update.synchronousUpdate()
-            XCTAssertEqual(storage.nextSince, "100000")
-            XCTAssert(storage.isCertificateRevoced(uvci: "a"))
-            XCTAssert(storage.isCertificateRevoced(uvci: "b"))
-            XCTAssert(storage.isCertificateRevoced(uvci: "c"))
-            revs.forEach { uvci in
-                XCTAssert(storage.isCertificateRevoced(uvci: uvci))
-            }
-            XCTAssertEqual(session.requests.count, 20)
-        }
 
-        func testPrePackagedDecoding() {
-            let storage = RevocationStorage(enviroment: .prod)
-
-            XCTAssertNotNil(storage.nextSince)
-            XCTAssertNotEqual(storage.lastDownload, 0)
-            XCTAssertNotEqual(storage.validDuration, 0)
+            let since: Int = lastNextSince == nil ? 0 : Int(lastNextSince!)!
+            let nextSince = min(since + 5000, revs.count)
+            let list = RevocationList()
+            list.revokedCerts = Set<String>(revs[since ... nextSince])
+            let data = try! JSONEncoder().encode(list)
+            let httpResponse = HTTPURLResponse(url: URL(string: "http://ubique.ch")!, statusCode: 200, httpVersion: nil, headerFields: [
+                "up-to-date": nextSince == revs.count ? "true" : "false",
+                "x-next-since": String(nextSince),
+            ])
+            lastNextSince = String(nextSince)
+            return (data, httpResponse, nil)
         }
-     */
+        let update = RevocationListUpdate(trustStorage: storage, decoder: RevocationListJSONDecoder(), session: session)
+        _ = update.synchronousUpdate()
+        XCTAssertEqual(storage.nextSince, "100000")
+        XCTAssert(storage.isCertificateRevoced(uvci: "a"))
+        XCTAssert(storage.isCertificateRevoced(uvci: "b"))
+        XCTAssert(storage.isCertificateRevoced(uvci: "c"))
+        revs.forEach { uvci in
+            XCTAssert(storage.isCertificateRevoced(uvci: uvci))
+        }
+        XCTAssertEqual(session.requests.count, 20)
+    }
+
+    func testPrePackagedDecoding() {
+        let storage = RevocationStorage(enviroment: .prod)
+
+        XCTAssertNotNil(storage.nextSince)
+        XCTAssertNotEqual(storage.lastDownload, 0)
+        XCTAssertNotEqual(storage.validDuration, 0)
+    }
 }
 
 class RevocationListJSONDecoder: RevocationListDecoder {


### PR DESCRIPTION
This PR speeds up the download/insertion of new revoked UVCIs